### PR TITLE
initialize project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ tools/flink
 tools/flink-*
 tools/releasing/release
 tools/japicmp-output
+flink-connectors/flink-connector-hive/.factorypath

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/dispatcher/StreamManagerDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/dispatcher/StreamManagerDispatcher.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.controlplane.dispatcher;
+
+/**
+ * Base class for the StreamManagerDispatcher component. The StreamManagerDispatcher
+ * component is responsible for receiving job submissions, persisting them, spawning
+ * StreamManagers to control the JobManagers and to recover them in case of a master
+ * failure.
+ */
+public abstract class StreamManagerDispatcher {
+	public static final String DISPATCHER_NAME = "streammanagerdispatcher";
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/dispatcher/StreamManagerDispatcherFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/dispatcher/StreamManagerDispatcherFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.controlplane.dispatcher;
+
+import org.apache.flink.runtime.rpc.RpcService;
+
+import java.util.UUID;
+
+/**
+ * {@link StreamManagerDispatcher} factory interface.
+ */
+public interface StreamManagerDispatcherFactory {
+
+	StreamManagerDispatcher createStreamManagerDispatcher(
+		RpcService rpcService,
+		StreamManagerDispatcherId fencingToken
+	) throws Exception;
+
+	default String generateEndpointIdWithUUID() {
+		return getEndpointId() + UUID.randomUUID();
+	}
+
+	default String getEndpointId() {
+		return StreamManagerDispatcher.DISPATCHER_NAME;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/dispatcher/StreamManagerDispatcherGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/dispatcher/StreamManagerDispatcherGateway.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.controlplane.dispatcher;
+
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+
+public interface StreamManagerDispatcherGateway extends DispatcherGateway{
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/dispatcher/StreamManagerDispatcherId.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/dispatcher/StreamManagerDispatcherId.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.controlplane.dispatcher;
+
+import org.apache.flink.util.AbstractID;
+
+import java.util.UUID;
+
+/**
+ * Fencing token of the {@link StreamManagerDispatcher}.
+ */
+
+public class StreamManagerDispatcherId extends AbstractID {
+
+	private static final long serialVersionUID = 1L; // TODO: generate real serialVersionUID with plugin
+
+	private StreamManagerDispatcherId() {}
+
+	private StreamManagerDispatcherId(UUID uuid) {
+		super(uuid.getLeastSignificantBits(), uuid.getMostSignificantBits());
+	}
+
+	public UUID toUUID() {
+		return new UUID(getUpperPart(), getLowerPart());
+	}
+
+	/**
+	 * Generates a new random DispatcherId.
+	 */
+	public static org.apache.flink.runtime.controlplane.dispatcher.StreamManagerDispatcherId generate() {
+		return new org.apache.flink.runtime.controlplane.dispatcher.StreamManagerDispatcherId();
+	}
+
+	/**
+	 * Creates a new DispatcherId that corresponds to the UUID.
+	 */
+	public static org.apache.flink.runtime.controlplane.dispatcher.StreamManagerDispatcherId fromUuid(UUID uuid) {
+		return new org.apache.flink.runtime.controlplane.dispatcher.StreamManagerDispatcherId(uuid);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/dispatcher/StreamManagerDispatcherRestEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/dispatcher/StreamManagerDispatcherRestEndpoint.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.controlplane.dispatcher;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.TransientBlobService;
+import org.apache.flink.runtime.leaderelection.LeaderElectionService;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.rest.RestServerEndpointConfiguration;
+import org.apache.flink.runtime.rest.handler.RestHandlerConfiguration;
+import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
+import org.apache.flink.runtime.rest.handler.job.JobSubmitHandler;
+import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.webmonitor.WebMonitorEndpoint;
+import org.apache.flink.runtime.webmonitor.WebMonitorExtension;
+import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * REST endpoint for the {@link StreamManagerDispatcher} component.
+ */
+public class StreamManagerDispatcherRestEndpoint extends WebMonitorEndpoint<StreamManagerDispatcherGateway> {
+
+	private WebMonitorExtension webSubmissionExtension;
+
+	public StreamManagerDispatcherRestEndpoint(
+			RestServerEndpointConfiguration endpointConfiguration,
+			GatewayRetriever<StreamManagerDispatcherGateway> leaderRetriever,
+			Configuration clusterConfiguration,
+			RestHandlerConfiguration restConfiguration,
+			GatewayRetriever<ResourceManagerGateway> resourceManagerRetriever,
+			TransientBlobService transientBlobService,
+			ScheduledExecutorService executor,
+			MetricFetcher metricFetcher,
+			LeaderElectionService leaderElectionService,
+			ExecutionGraphCache executionGraphCache,
+			FatalErrorHandler fatalErrorHandler) throws IOException {
+
+		super(
+			endpointConfiguration,
+			leaderRetriever,
+			clusterConfiguration,
+			restConfiguration,
+			resourceManagerRetriever,
+			transientBlobService,
+			executor,
+			metricFetcher,
+			leaderElectionService,
+			executionGraphCache,
+			fatalErrorHandler);
+
+		webSubmissionExtension = WebMonitorExtension.empty();
+	}
+
+	@Override
+	protected List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(final CompletableFuture<String> localAddressFuture) {
+		List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers = super.initializeHandlers(localAddressFuture);
+
+		// Add the Dispatcher specific handlers
+
+		final Time timeout = restConfiguration.getTimeout();
+
+		JobSubmitHandler jobSubmitHandler = new JobSubmitHandler(
+			leaderRetriever,
+			timeout,
+			responseHeaders,
+			executor,
+			clusterConfiguration);
+
+		if (restConfiguration.isWebSubmitEnabled()) {
+			try {
+				webSubmissionExtension = WebMonitorUtils.loadWebSubmissionExtension(
+					leaderRetriever,
+					timeout,
+					responseHeaders,
+					localAddressFuture,
+					uploadDir,
+					executor,
+					clusterConfiguration);
+
+				// register extension handlers
+				handlers.addAll(webSubmissionExtension.getHandlers());
+			} catch (FlinkException e) {
+				if (log.isDebugEnabled()) {
+					log.debug("Failed to load web based job submission extension.", e);
+				} else {
+					log.info("Failed to load web based job submission extension. " +
+						"Probable reason: flink-runtime-web is not in the classpath.");
+				}
+			}
+		} else {
+			log.info("Web-based job submission is not enabled.");
+		}
+
+		handlers.add(Tuple2.of(jobSubmitHandler.getMessageHeaders(), jobSubmitHandler));
+
+		return handlers;
+	}
+
+	@Override
+	protected CompletableFuture<Void> shutDownInternal() {
+		final CompletableFuture<Void> shutdownFuture = super.shutDownInternal();
+
+		final CompletableFuture<Void> shutdownResultFuture = new CompletableFuture<>();
+
+		shutdownFuture.whenComplete(
+			(Void ignored, Throwable throwable) -> {
+				webSubmissionExtension.closeAsync().whenComplete(
+					(Void innerIgnored, Throwable innerThrowable) -> {
+						if (innerThrowable != null) {
+							shutdownResultFuture.completeExceptionally(
+								ExceptionUtils.firstOrSuppressed(innerThrowable, throwable));
+						} else if (throwable != null) {
+							shutdownResultFuture.completeExceptionally(throwable);
+						} else {
+							shutdownResultFuture.complete(null);
+						}
+					});
+			});
+
+		return shutdownResultFuture;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/dispatcher/StreamManagerRunnerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/dispatcher/StreamManagerRunnerFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.controlplane.dispatcher;
+
+import org.apache.flink.configuration.Configuration;
+//import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.controlplane.streammaster.StreamManagerRunner;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+
+/**
+ * Factory for a {@link StreamManagerRunner}.
+ */
+@FunctionalInterface
+public interface StreamManagerRunnerFactory {
+
+	StreamManagerRunner createJobManagerRunner(
+		JobGraph jobGraph,
+		Configuration configuration,
+		RpcService rpcService,
+		HighAvailabilityServices highAvailabilityServices,
+//		HeartbeatServices heartbeatServices, // TODO: to be considered
+		FatalErrorHandler fatalErrorHandler) throws Exception;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/rest/StreamManagerRestEndpointFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/rest/StreamManagerRestEndpointFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.controlplane.rest;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.TransientBlobService;
+import org.apache.flink.runtime.controlplane.dispatcher.StreamManagerDispatcherGateway;
+import org.apache.flink.runtime.controlplane.dispatcher.StreamManagerDispatcherRestEndpoint;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.leaderelection.LeaderElectionService;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.rest.RestEndpointFactory;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.webmonitor.WebMonitorEndpoint;
+import org.apache.flink.runtime.webmonitor.retriever.LeaderGatewayRetriever;
+
+/**
+ * {@link RestEndpointFactory} which creates a {@link StreamManagerDispatcherRestEndpoint}.
+ */
+public enum StreamManagerRestEndpointFactory implements RestEndpointFactory<StreamManagerDispatcherGateway> {
+    INSTANCE;
+
+    @Override
+    public WebMonitorEndpoint<StreamManagerDispatcherGateway> createRestEndpoint(Configuration configuration,
+            LeaderGatewayRetriever<DispatcherGateway> dispatcherGatewayRetriever,
+            LeaderGatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever,
+            TransientBlobService transientBlobService, ScheduledExecutorService executor, MetricFetcher metricFetcher,
+            LeaderElectionService leaderElectionService, FatalErrorHandler fatalErrorHandler) throws Exception {
+        // TODO Auto-generated method stub
+        return null;
+    }
+    
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammaster/StreamManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammaster/StreamManagerRunner.java
@@ -19,8 +19,6 @@
 package org.apache.flink.runtime.controlplane.streammaster;
 
 import org.apache.flink.api.common.JobID;
-//import org.apache.flink.runtime.jobmaster.JobMaster;
-//import org.apache.flink.runtime.jobmaster.JobMasterGateway;
 import org.apache.flink.util.AutoCloseableAsync;
 
 import java.util.concurrent.CompletableFuture;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammaster/StreamManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammaster/StreamManagerRunner.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.controlplane.streammaster;
+
+import org.apache.flink.api.common.JobID;
+//import org.apache.flink.runtime.jobmaster.JobMaster;
+//import org.apache.flink.runtime.jobmaster.JobMasterGateway;
+import org.apache.flink.util.AutoCloseableAsync;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Interface for a runner which executes a {@link StreamMaster}.
+ */
+public interface StreamManagerRunner extends AutoCloseableAsync {
+
+	/**
+	 * Start the execution of the {@link StreamMaster}.
+	 *
+	 * @throws Exception if the JobMaster cannot be started
+	 */
+	void start() throws Exception;
+
+	/**
+	 * Get the {@link StreamMasterGateway} of the {@link StreamMaster}. The future is
+	 * only completed if the JobMaster becomes leader.
+	 *
+	 * @return Future with the JobMasterGateway once the underlying JobMaster becomes leader
+	 */
+	CompletableFuture<StreamMasterGateway> getJobMasterGateway();
+
+	/**
+	 * Get the job id of the executed job.
+	 *
+	 * @return job id of the executed job
+	 */
+	JobID getJobID();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammaster/StreamMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammaster/StreamMaster.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.runtime.controlplane.streammaster;
 
 public class StreamMaster {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammaster/StreamMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammaster/StreamMaster.java
@@ -1,0 +1,4 @@
+package org.apache.flink.runtime.controlplane.streammaster;
+
+public class StreamMaster {
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammaster/StreamMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammaster/StreamMasterGateway.java
@@ -1,0 +1,4 @@
+package org.apache.flink.runtime.controlplane.streammaster;
+
+public interface StreamMasterGateway {
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammaster/StreamMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammaster/StreamMasterGateway.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.runtime.controlplane.streammaster;
 
 public interface StreamMasterGateway {


### PR DESCRIPTION
<!--
这个模板是我根据flink官方提供的pull request的模板适配的。
尽量根据这个pull request模板附上pull request的信息吧！
-->

## What is the purpose of the change

  This pull request initializes the project structure for our `flink.runtime.controlplane`.

```
├── dispatcher
│   ├── StreamManagerDispatcher*.java
│   ├── StreamManagerDispatcherRestEndpoint.java
│   └── StreamManagerRunnerFactory.java
├── rest
│   └── StreamManagerRestEndpointFactory.java
└── streammaster
    ├── StreamManagerRunner.java
    ├── StreamMaster.java
    └── StreamMasterGateway.java
```


## Brief change log

  - add `flink-connectors/flink-connector-hive/.factorypath` to .gitignore
  - add files under `flink-runtime/.../runtime/controlplane`

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
