### PR TITLE
Complete trial initialization for StreamManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/dispatcher/DefaultStreamManagerRunnerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/dispatcher/DefaultStreamManagerRunnerFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.controlplane.dispatcher;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.controlplane.streammanager.StreamManagerConfiguration;
+import org.apache.flink.runtime.controlplane.streammanager.StreamManagerRunner;
+import org.apache.flink.runtime.controlplane.streammanager.StreamManagerRunnerImpl;
+import org.apache.flink.runtime.controlplane.streammanager.factories.DefaultStreamManagerServiceFactory;
+import org.apache.flink.runtime.controlplane.streammanager.factories.StreamManagerServiceFactory;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.util.ExecutorThreadFactory;
+import org.apache.flink.runtime.util.Hardware;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * @author trx
+ * Singleton default factory for {@link StreamManagerRunner}
+ */
+public enum DefaultStreamManagerRunnerFactory implements StreamManagerRunnerFactory {
+    INSTANCE;
+
+    @Override
+    public StreamManagerRunner createStreamManagerRunner(
+            JobGraph jobGraph,
+            Configuration configuration,
+            RpcService rpcService,
+            HighAvailabilityServices highAvailabilityServices,
+            HeartbeatServices heartbeatServices,
+            FatalErrorHandler fatalErrorHandler) throws Exception {
+
+        final StreamManagerConfiguration streamManagerConfiguration = StreamManagerConfiguration.fromConfiguration(configuration);
+
+        final StreamManagerServiceFactory streamManagerServiceFactory = new DefaultStreamManagerServiceFactory(
+                streamManagerConfiguration,
+                rpcService,
+                highAvailabilityServices,
+                heartbeatServices,
+                fatalErrorHandler
+        );
+
+        // TODO: move in StreamManagerSharedServices
+        final ScheduledExecutorService futureExecutor = Executors.newScheduledThreadPool(
+                Hardware.getNumberCPUCores(),
+                new ExecutorThreadFactory("streammanager-future"));
+
+        return new StreamManagerRunnerImpl(
+                jobGraph,
+                streamManagerServiceFactory,
+                highAvailabilityServices,
+                futureExecutor,
+                fatalErrorHandler);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/dispatcher/StreamManagerRunnerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/dispatcher/StreamManagerRunnerFactory.java
@@ -20,23 +20,25 @@ package org.apache.flink.runtime.controlplane.dispatcher;
 
 import org.apache.flink.configuration.Configuration;
 
-import org.apache.flink.runtime.controlplane.streammaster.StreamManagerRunner;
+import org.apache.flink.runtime.controlplane.streammanager.StreamManagerRunner;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 
 /**
+ * @author trx
  * Factory for a {@link StreamManagerRunner}.
  */
 @FunctionalInterface
 public interface StreamManagerRunnerFactory {
 
-	StreamManagerRunner createJobManagerRunner(
-		JobGraph jobGraph,
-		Configuration configuration,
-		RpcService rpcService,
-		HighAvailabilityServices highAvailabilityServices,
-//		HeartbeatServices heartbeatServices, // TODO: to be considered
-		FatalErrorHandler fatalErrorHandler) throws Exception;
+	StreamManagerRunner createStreamManagerRunner(
+			JobGraph jobGraph,
+			Configuration configuration,
+			RpcService rpcService,
+			HighAvailabilityServices highAvailabilityServices,
+			HeartbeatServices heartbeatServices, // TODO: to be considered
+			FatalErrorHandler fatalErrorHandler) throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManager.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.controlplane.streammanager;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.heartbeat.HeartbeatManager;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * @author trx
+ * StreamManager implementation.
+ *
+ * TODO:
+ * 1. decide other fields
+ * 2. initialize other fields
+ */
+public class StreamManager extends FencedRpcEndpoint<StreamManagerId> implements StreamManagerGateway, StreamManagerService{
+
+    /** Default names for Flink's distributed components. */
+    public static final String Stream_Manager_NAME = "streammanager";
+
+    private final StreamManagerConfiguration streamManagerConfiguration;
+
+    private final ResourceID resourceId;
+
+    private final JobGraph jobGraph;
+
+    private final Time rpcTimeout;
+
+    private final HighAvailabilityServices highAvailabilityServices;
+
+    private final FatalErrorHandler fatalErrorHandler;
+
+    private final HeartbeatServices heartbeatServices;
+
+    /*
+
+    // --------- JobManager --------
+
+    private final LeaderRetrievalService jobManagerLeaderRetriever;
+
+    // -------- Mutable fields ---------
+
+    private HeartbeatManager<Void, Void> jobManagerHeartbeatManager;
+
+    TODO: other connection and listener related
+
+    */
+
+    // ------------------------------------------------------------------------
+
+    public StreamManager(RpcService rpcService,
+                         StreamManagerConfiguration streamManagerConfiguration,
+                         ResourceID resourceId,
+                         JobGraph jobGraph,
+                         HighAvailabilityServices highAvailabilityService,
+                         HeartbeatServices heartbeatServices,
+                         FatalErrorHandler fatalErrorHandler) throws Exception{
+        super(rpcService, AkkaRpcServiceUtils.createRandomName(Stream_Manager_NAME), null);
+
+        this.streamManagerConfiguration = checkNotNull(streamManagerConfiguration);
+        this.resourceId = checkNotNull(resourceId);
+        this.jobGraph = checkNotNull(jobGraph);
+        this.rpcTimeout = streamManagerConfiguration.getRpcTimeout();
+        this.highAvailabilityServices = checkNotNull(highAvailabilityService);
+        this.fatalErrorHandler = checkNotNull(fatalErrorHandler);
+        this.heartbeatServices = checkNotNull(heartbeatServices);
+
+        final String jobName = jobGraph.getName();
+        final JobID jid = jobGraph.getJobID();
+
+        log.debug("Initializing sm for job {} ({})", jobName, jid);
+
+        /*
+        TODO: initialize other fields
+         */
+    }
+
+    /**
+     * Disconnects the job manager from the stream manager because of the given cause.
+     *
+     * @param jobMasterId identifying the job manager leader id
+     * @param cause       of the disconnect
+     */
+    @Override
+    public void disconnectJobMaster(JobMasterId jobMasterId, Exception cause) {
+    }
+
+    /**
+     * Start the StreamManager service with the given {@link StreamManagerId}.
+     *
+     * @param newStreamManagerId to start the service with
+     * @return Future which is completed once the StreamManager service has been started
+     * @throws Exception if the StreamManager service could not be started
+     */
+    @Override
+    public CompletableFuture<Acknowledge> start(StreamManagerId newStreamManagerId) throws Exception {
+        // make sure we receive RPC and async calls
+        start();
+
+        return callAsyncWithoutFencing(() -> startStreamManagement(newStreamManagerId), RpcUtils.INF_TIMEOUT);
+    }
+
+    /**
+     * Suspend the StreamManager service. This means that the service will stop to react
+     * to messages.
+     *
+     * @param cause for the suspension
+     * @return Future which is completed once the StreamManager service has been suspended
+     */
+    @Override
+    public CompletableFuture<Acknowledge> suspend(Exception cause) {
+        CompletableFuture<Acknowledge> suspendFuture = callAsyncWithoutFencing(
+                () -> suspendManagement(cause),
+                RpcUtils.INF_TIMEOUT);
+        return suspendFuture.whenComplete(((acknowledge, throwable) -> stop()));
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // Internal methods
+    //----------------------------------------------------------------------------------------------
+
+    private Acknowledge startStreamManagement(StreamManagerId newStreamManagerId) throws Exception {
+
+        validateRunsInMainThread();
+
+        checkNotNull(newStreamManagerId, "The new StreamManagerId must not be null");
+
+        return Acknowledge.get();
+    }
+
+    /**
+     * Suspending stream manager, (cancel the job, to be consider), and other communication with other components
+     * will be disposed.
+     * @param cause The reason of why this stream manger been suspended.
+     */
+    private Acknowledge suspendManagement(final Exception cause) {
+        validateRunsInMainThread();
+
+        if (getFencingToken() == null) {
+            log.debug("Stream Management has already benn suspended or shutdown.");
+            return Acknowledge.get();
+        }
+
+        // not leader anymore --> set the StreamManagerId to null
+        setFencingToken(null);
+
+        // TODO:
+        // closeJobManagerConnection(cause);
+
+        // stop other services
+
+        return Acknowledge.get();
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // Service methods
+    //----------------------------------------------------------------------------------------------
+
+    /**
+     * Get the {@link StreamManagerGateway} belonging to this service.
+     *
+     * @return StreamManagerGateway belonging to this service
+     */
+    @Override
+    public StreamManager getGateway() {
+        return getSelfGateway(StreamManager.class);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerConfiguration.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.controlplane.streammanager;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.jobmaster.JobMaster;
+import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * @author trx
+ * Configuration for the {@link StreamManager}.
+ */
+public class StreamManagerConfiguration {
+
+	private final Time rpcTimeout;
+
+	private final Time slotRequestTimeout;
+
+	private final String tmpDirectory;
+
+	private final RetryingRegistrationConfiguration retryingRegistrationConfiguration;
+
+	private final Configuration configuration;
+
+	public StreamManagerConfiguration(
+			Time rpcTimeout,
+			Time slotRequestTimeout,
+			String tmpDirectory,
+			RetryingRegistrationConfiguration retryingRegistrationConfiguration,
+			Configuration configuration) {
+		this.rpcTimeout = Preconditions.checkNotNull(rpcTimeout);
+		this.slotRequestTimeout = Preconditions.checkNotNull(slotRequestTimeout);
+		this.tmpDirectory = Preconditions.checkNotNull(tmpDirectory);
+		this.retryingRegistrationConfiguration = retryingRegistrationConfiguration;
+		this.configuration = Preconditions.checkNotNull(configuration);
+	}
+
+	public Time getRpcTimeout() {
+		return rpcTimeout;
+	}
+
+	public Time getSlotRequestTimeout() {
+		return slotRequestTimeout;
+	}
+
+	public String getTmpDirectory() {
+		return tmpDirectory;
+	}
+
+	public RetryingRegistrationConfiguration getRetryingRegistrationConfiguration() {
+		return retryingRegistrationConfiguration;
+	}
+
+	public Configuration getConfiguration() {
+		return configuration;
+	}
+
+	public static StreamManagerConfiguration fromConfiguration(Configuration configuration) {
+
+//		final Time rpcTimeout = AkkaUtils.getTimeoutAsTime(configuration);
+		final Time rpcTimeout = RpcUtils.INF_TIMEOUT;
+
+		final Time slotRequestTimeout = Time.milliseconds(configuration.getLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT));
+
+		final String tmpDirectory = ConfigurationUtils.parseTempDirectories(configuration)[0];
+
+		final RetryingRegistrationConfiguration retryingRegistrationConfiguration = RetryingRegistrationConfiguration.fromConfiguration(configuration);
+
+		return new StreamManagerConfiguration(
+			rpcTimeout,
+			slotRequestTimeout,
+			tmpDirectory,
+			retryingRegistrationConfiguration,
+			configuration);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerGateway.java
@@ -16,10 +16,24 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.controlplane.streammaster;
+package org.apache.flink.runtime.controlplane.streammanager;
+
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.rpc.FencedRpcGateway;
 
 /**
- * StreamMaster implementation.
+ * {@link StreamManager} rpc gateway interface
  */
-public class StreamMaster {
+public interface StreamManagerGateway extends FencedRpcGateway<StreamManagerId> {
+
+    /*
+     * Disconnects the job manager from the stream manager because of the given cause.
+     *
+     * @param jobMasterId identifying the job manager leader id
+     * @param cause of the disconnect
+     */
+    void disconnectJobMaster(
+            final JobMasterId jobMasterId,
+            final Exception cause);
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerId.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerId.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.controlplane.streammanager;
+
+import org.apache.flink.util.AbstractID;
+
+import javax.annotation.Nullable;
+import java.util.UUID;
+
+/**
+ * The {@link StreamManager} fencing token.
+ */
+public class StreamManagerId extends AbstractID {
+
+	private static final long serialVersionUID = -1065386276246562408L;
+
+	/**
+	 * Creates a StreamManagerId that takes the bits from the given UUID.
+	 */
+	public StreamManagerId(UUID uuid) {
+		super(uuid.getLeastSignificantBits(), uuid.getMostSignificantBits());
+	}
+
+	/**
+	 * Generates a new random StreamManagerId.
+	 */
+	private StreamManagerId() {
+		super();
+	}
+
+	/**
+	 * Creates a UUID with the bits from this StreamManagerId.
+	 */
+	public UUID toUUID() {
+		return new UUID(getUpperPart(), getLowerPart());
+	}
+
+	/**
+	 * Generates a new random JobMasterId.
+	 */
+	public static StreamManagerId generate() {
+		return new StreamManagerId();
+	}
+
+	/**
+	 * If the given uuid is null, this returns null, otherwise a StreamManagerId that
+	 * corresponds to the UUID, via {@link #StreamManagerId(UUID)}.
+	 */
+	public static StreamManagerId fromUuidOrNull(@Nullable UUID uuid) {
+		return  uuid == null ? null : new StreamManagerId(uuid);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerRunner.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.controlplane.streammaster;
+package org.apache.flink.runtime.controlplane.streammanager;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.util.AutoCloseableAsync;
@@ -24,24 +24,24 @@ import org.apache.flink.util.AutoCloseableAsync;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Interface for a runner which executes a {@link StreamMaster}.
+ * Interface for a runner which executes a {@link StreamManager}.
  */
 public interface StreamManagerRunner extends AutoCloseableAsync {
 
 	/**
-	 * Start the execution of the {@link StreamMaster}.
+	 * Start the execution of the {@link StreamManager}.
 	 *
 	 * @throws Exception if the JobMaster cannot be started
 	 */
 	void start() throws Exception;
 
 	/**
-	 * Get the {@link StreamMasterGateway} of the {@link StreamMaster}. The future is
+	 * Get the {@link StreamManagerGateway} of the {@link StreamManager}. The future is
 	 * only completed if the JobMaster becomes leader.
 	 *
 	 * @return Future with the JobMasterGateway once the underlying JobMaster becomes leader
 	 */
-	CompletableFuture<StreamMasterGateway> getJobMasterGateway();
+	CompletableFuture<StreamManagerGateway> getJobMasterGateway();
 
 	/**
 	 * Get the job id of the executed job.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerRunnerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerRunnerImpl.java
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.controlplane.streammanager;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.controlplane.streammanager.factories.StreamManagerServiceFactory;
+import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.RunningJobsRegistry;
+import org.apache.flink.runtime.highavailability.RunningJobsRegistry.JobSchedulingStatus;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmanager.OnCompletionActions;
+import org.apache.flink.runtime.jobmaster.*;
+import org.apache.flink.runtime.jobmaster.factories.JobMasterServiceFactory;
+import org.apache.flink.runtime.leaderelection.LeaderContender;
+import org.apache.flink.runtime.leaderelection.LeaderElectionService;
+import org.apache.flink.runtime.leaderelection.StandaloneLeaderElectionService;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.function.FunctionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * @author trx
+ * The runner for the stream manager.
+ */
+public class StreamManagerRunnerImpl implements LeaderContender, StreamManagerRunner {
+
+	private static final Logger log = LoggerFactory.getLogger(StreamManagerRunnerImpl.class);
+
+	// ------------------------------------------------------------------------
+
+	/** Lock to ensure that this runner can deal with leader election event and notifies simultaneously. */
+	private final Object lock = new Object();
+
+	/** The job graph needs to run. */
+	private final JobGraph jobGraph;
+
+//	/** Used to check whether a job needs to be run. */
+//	private final RunningJobsRegistry runningJobsRegistry;
+
+	/** Leader election for this stream manger. */
+	private final LeaderElectionService leaderElectionService;
+
+// TODO: use LCM
+//	private final LibraryCacheManager libraryCacheManager;
+
+	private final Executor executor;
+
+	private final StreamManagerService streamManagerService;
+
+	private final FatalErrorHandler fatalErrorHandler;
+
+	private final CompletableFuture<ArchivedExecutionGraph> resultFuture;
+
+	private final CompletableFuture<Void> terminationFuture;
+
+	private CompletableFuture<Void> leadershipOperation;
+
+	/** flag marking the runner as shut down. */
+	private volatile boolean shutdown;
+
+	private volatile CompletableFuture<StreamManagerGateway> leaderGatewayFuture;
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Exceptions that occur while creating the JobManager or JobManagerRunnerImpl are directly
+	 * thrown and not reported to the given {@code FatalErrorHandler}.
+	 *
+	 * @throws Exception Thrown if the runner cannot be set up, because either one of the
+	 *                   required services could not be started, or the Job could not be initialized.
+	 */
+	public StreamManagerRunnerImpl(
+			final JobGraph jobGraph,
+			final StreamManagerServiceFactory streamManagerFactory,
+			final HighAvailabilityServices haServices,
+			final Executor executor,
+			final FatalErrorHandler fatalErrorHandler) throws Exception {
+
+		this.resultFuture = new CompletableFuture<>();
+		this.terminationFuture = new CompletableFuture<>();
+		this.leadershipOperation = CompletableFuture.completedFuture(null);
+
+		// make sure we cleanly shut down out JobManager services if initialization fails
+		try {
+			this.jobGraph = checkNotNull(jobGraph);
+			this.executor = checkNotNull(executor);
+			this.fatalErrorHandler = checkNotNull(fatalErrorHandler);
+
+			checkArgument(jobGraph.getNumberOfVertices() > 0, "The given job is empty");
+
+			// libraries and class loader first
+
+			// high availability services next
+			// TODO: 1. change back and 2. add getStreamManagerLES in HA
+//			this.leaderElectionService = haServices.getJobManagerLeaderElectionService(jobGraph.getJobID());
+			this.leaderElectionService = new StandaloneLeaderElectionService();
+
+			this.leaderGatewayFuture = new CompletableFuture<>();
+
+			// now start the StreamManager
+			this.streamManagerService = streamManagerFactory.createStreamManagerService(jobGraph);
+		}
+		catch (Throwable t) {
+			terminationFuture.completeExceptionally(t);
+			resultFuture.completeExceptionally(t);
+
+			throw new JobExecutionException(jobGraph.getJobID(), "Could not set up StreamManager", t);
+		}
+	}
+
+	//----------------------------------------------------------------------------------------------
+	// Getter
+	//----------------------------------------------------------------------------------------------
+
+	@Override
+	public CompletableFuture<StreamManagerGateway> getJobMasterGateway() {
+		return leaderGatewayFuture;
+	}
+
+	@Override
+	public JobID getJobID() {
+		return jobGraph.getJobID();
+	}
+
+	//----------------------------------------------------------------------------------------------
+	// Lifecycle management
+	//----------------------------------------------------------------------------------------------
+
+	@Override
+	public void start() throws Exception {
+		try {
+			leaderElectionService.start(this);
+		} catch (Exception e) {
+			log.error("Could not start the JobManager because the leader election service did not start.", e);
+			throw new Exception("Could not start the leader election service.", e);
+		}
+	}
+
+	@Override
+	public CompletableFuture<Void> closeAsync() {
+		synchronized (lock) {
+			if (!shutdown) {
+				shutdown = true;
+				// TODO
+			}
+
+			return terminationFuture;
+		}
+	}
+
+	//----------------------------------------------------------------------------------------------
+	// Result and error handling methods
+	//----------------------------------------------------------------------------------------------
+
+	private void handleJobManagerRunnerError(Throwable cause) {
+		if (ExceptionUtils.isJvmFatalError(cause)) {
+			fatalErrorHandler.onFatalError(cause);
+		} else {
+			resultFuture.completeExceptionally(cause);
+		}
+	}
+
+	//----------------------------------------------------------------------------------------------
+	// Leadership methods
+	//----------------------------------------------------------------------------------------------
+
+	@Override
+	public void grantLeadership(final UUID leaderSessionID) {
+		synchronized (lock) {
+			if (shutdown) {
+				log.info("JobManagerRunner already shutdown.");
+				return;
+			}
+
+			leadershipOperation = leadershipOperation.thenCompose(
+				(ignored) -> {
+					synchronized (lock) {
+//						return verifySomethingAndStartStreamManager(leaderSessionID);
+						return startStreamManager(leaderSessionID);
+					}
+				});
+
+			handleException(leadershipOperation, "Could not start the stream manager.");
+		}
+	}
+
+	private CompletableFuture<Void> verifySomethingAndStartStreamManager(UUID leaderSessionId) {
+//		final CompletableFuture<JobSchedulingStatus> jobSchedulingStatusFuture = getJobSchedulingStatus();
+//		return jobSchedulingStatusFuture.thenCompose(
+//			jobSchedulingStatus -> {
+//				if (jobSchedulingStatus == JobSchedulingStatus.DONE) {
+//					return jobAlreadyDone();
+//				} else {
+//					return startJobMaster(leaderSessionId);
+//				}
+//			});
+		return null;
+	}
+
+	private CompletionStage<Void> startStreamManager(UUID leaderSessionId) {
+		log.debug("StreamManager runner for job {} ({}) was granted leadership with session id {} at {}.",
+			jobGraph.getName(), jobGraph.getJobID(), leaderSessionId, streamManagerService.getAddress());
+
+		final CompletableFuture<Acknowledge> startFuture;
+		try {
+			startFuture = streamManagerService.start(new StreamManagerId(leaderSessionId));
+		} catch (Exception e) {
+			return FutureUtils.completedExceptionally(new FlinkException("Failed to start the StreamManager.", e));
+		}
+
+		final CompletableFuture<StreamManagerGateway> currentLeaderGatewayFuture = leaderGatewayFuture;
+		return startFuture.thenAcceptAsync(
+			(Acknowledge ack) -> confirmLeaderSessionIdIfStillLeader(
+				leaderSessionId,
+				streamManagerService.getAddress(),
+				currentLeaderGatewayFuture),
+			executor);
+	}
+
+	private void confirmLeaderSessionIdIfStillLeader(
+			UUID leaderSessionId,
+			String leaderAddress,
+			CompletableFuture<StreamManagerGateway> currentLeaderGatewayFuture) {
+
+		if (leaderElectionService.hasLeadership(leaderSessionId)) {
+			currentLeaderGatewayFuture.complete(streamManagerService.getGateway());
+			leaderElectionService.confirmLeadership(leaderSessionId, leaderAddress);
+		} else {
+			log.debug("Ignoring confirmation of leader session id because {} is no longer the leader.", getDescription());
+		}
+	}
+
+	@Override
+	public void revokeLeadership() {
+		synchronized (lock) {
+			if (shutdown) {
+				log.info("JobManagerRunner already shutdown.");
+				return;
+			}
+
+			leadershipOperation = leadershipOperation.thenCompose(
+				(ignored) -> {
+					synchronized (lock) {
+						return revokeJobMasterLeadership();
+					}
+				});
+
+			handleException(leadershipOperation, "Could not suspend the job manager.");
+		}
+	}
+
+	private CompletableFuture<Void> revokeJobMasterLeadership() {
+		log.info("JobManager for job {} ({}) at {} was revoked leadership.",
+			jobGraph.getName(), jobGraph.getJobID(), streamManagerService.getAddress());
+
+		setNewLeaderGatewayFuture();
+
+		return streamManagerService
+			.suspend(new FlinkException("JobManager is no longer the leader."))
+			.thenApply(FunctionUtils.nullFn());
+	}
+
+	private void handleException(CompletableFuture<Void> leadershipOperation, String message) {
+		leadershipOperation.whenComplete(
+			(ignored, throwable) -> {
+				if (throwable != null) {
+					handleJobManagerRunnerError(new FlinkException(message, throwable));
+				}
+			});
+	}
+
+	private void setNewLeaderGatewayFuture() {
+		final CompletableFuture<StreamManagerGateway> oldLeaderGatewayFuture = leaderGatewayFuture;
+
+		leaderGatewayFuture = new CompletableFuture<>();
+
+		if (!oldLeaderGatewayFuture.isDone()) {
+			leaderGatewayFuture.whenComplete(
+				(StreamManagerGateway streamManagerGateway, Throwable throwable) -> {
+					if (throwable != null) {
+						oldLeaderGatewayFuture.completeExceptionally(throwable);
+					} else {
+						oldLeaderGatewayFuture.complete(streamManagerGateway);
+					}
+				});
+		}
+	}
+
+	@Override
+	public String getDescription() {
+		return streamManagerService.getAddress();
+	}
+
+	@Override
+	public void handleError(Exception exception) {
+		log.error("Leader Election Service encountered a fatal error.", exception);
+		handleJobManagerRunnerError(exception);
+	}
+
+	//----------------------------------------------------------------------------------------------
+	// Testing
+	//----------------------------------------------------------------------------------------------
+
+	@VisibleForTesting
+	boolean isShutdown() {
+		return shutdown;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerService.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.controlplane.streammanager;
+
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.util.AutoCloseableAsync;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * @author trx
+ * Interface which specifies the StreamManager service.
+ */
+public interface StreamManagerService extends AutoCloseableAsync {
+
+	/**
+	 * Start the StreamManager service with the given {@link StreamManagerId}.
+	 *
+	 * @param streamManagerId to start the service with
+	 * @return Future which is completed once the StreamManager service has been started
+	 * @throws Exception if the StreamManager service could not be started
+	 */
+	CompletableFuture<Acknowledge> start(StreamManagerId streamManagerId) throws Exception;
+
+	/**
+	 * Suspend the StreamManager service. This means that the service will stop to react
+	 * to messages.
+	 *
+	 * @param cause for the suspension
+	 * @return Future which is completed once the StreamManager service has been suspended
+	 */
+	CompletableFuture<Acknowledge> suspend(Exception cause);
+
+	/**
+	 * Get the {@link StreamManagerGateway} belonging to this service.
+	 *
+	 * @return StreamManagerGateway belonging to this service
+	 */
+	StreamManager getGateway();
+
+	/**
+	 * Get the address of the StreamManager service under which it is reachable.
+	 *
+	 * @return Address of the StreamManager service
+	 */
+	String getAddress();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/factories/DefaultStreamManagerServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/factories/DefaultStreamManagerServiceFactory.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.controlplane.streammanager.factories;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.controlplane.streammanager.StreamManager;
+import org.apache.flink.runtime.controlplane.streammanager.StreamManagerConfiguration;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
+
+/**
+ * Default implementation of the {@link StreamManagerServiceFactory}.
+ * TODO:
+ * 1. decide about the StreamManagerSharedServices
+ */
+public class DefaultStreamManagerServiceFactory implements StreamManagerServiceFactory {
+
+	private final StreamManagerConfiguration streamManagerConfiguration;
+
+	private final RpcService rpcService;
+
+	private final HighAvailabilityServices haServices;
+
+//	private final JobManagerSharedServices jobManagerSharedServices;
+	// TODO: May need StreamManagerSharedServices
+
+
+	private final HeartbeatServices heartbeatServices;
+
+	private final FatalErrorHandler fatalErrorHandler;
+
+	public DefaultStreamManagerServiceFactory(
+			StreamManagerConfiguration streamManagerConfiguration,
+			RpcService rpcService,
+			HighAvailabilityServices haServices,
+			HeartbeatServices heartbeatServices,
+			FatalErrorHandler fatalErrorHandler) {
+		this.streamManagerConfiguration = streamManagerConfiguration;
+		this.rpcService = rpcService;
+		this.haServices = haServices;
+		this.heartbeatServices = heartbeatServices;
+		this.fatalErrorHandler = fatalErrorHandler;
+	}
+
+	@Override
+	public StreamManager createStreamManagerService(
+			JobGraph jobGraph) throws Exception {
+
+		return new StreamManager(
+			rpcService,
+			streamManagerConfiguration,
+			ResourceID.generate(),
+			jobGraph,
+			haServices,
+			heartbeatServices,
+			fatalErrorHandler);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/factories/StreamManagerServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/factories/StreamManagerServiceFactory.java
@@ -16,10 +16,18 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.controlplane.streammaster;
+package org.apache.flink.runtime.controlplane.streammanager.factories;
+
+import org.apache.flink.runtime.controlplane.streammanager.StreamManagerService;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmanager.OnCompletionActions;
+import org.apache.flink.runtime.jobmaster.JobMasterService;
 
 /**
- * Gateway for StreamMaster Component.
+ * Factory for a {@link StreamManagerService}.
  */
-public interface StreamMasterGateway {
+public interface StreamManagerServiceFactory {
+
+	StreamManagerService createStreamManagerService(
+            JobGraph jobGraph) throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -102,7 +102,7 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
 
 	public static final String DISPATCHER_NAME = "dispatcher";
 
-	public static final boolean TEST_FLAG = true; // TODO: set to true to run the Stream Manager Only.
+	public static final boolean TEST_FLAG = false; // TODO: set to true to run the Stream Manager Only.
 
 	private final Configuration configuration;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -32,6 +32,10 @@ import org.apache.flink.runtime.client.JobSubmissionException;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.controlplane.dispatcher.DefaultStreamManagerRunnerFactory;
+import org.apache.flink.runtime.controlplane.dispatcher.StreamManagerRunnerFactory;
+import org.apache.flink.runtime.controlplane.streammanager.StreamManager;
+import org.apache.flink.runtime.controlplane.streammanager.StreamManagerRunner;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -97,6 +101,8 @@ import java.util.stream.Collectors;
 public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<DispatcherId> implements DispatcherGateway {
 
 	public static final String DISPATCHER_NAME = "dispatcher";
+
+	public static final boolean TEST_FLAG = true; // TODO: set to true to run the Stream Manager Only.
 
 	private final Configuration configuration;
 
@@ -345,13 +351,36 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
 	private CompletableFuture<Void> persistAndRunJob(JobGraph jobGraph) throws Exception {
 		jobGraphWriter.putJobGraph(jobGraph);
 
-		final CompletableFuture<Void> runJobFuture = runJob(jobGraph);
+		if (!TEST_FLAG) {
+			final CompletableFuture<Void> runJobFuture = runJob(jobGraph);
 
-		return runJobFuture.whenComplete(BiConsumerWithException.unchecked((Object ignored, Throwable throwable) -> {
+			return runJobFuture.whenComplete(BiConsumerWithException.unchecked((Object ignored, Throwable throwable) -> {
+				if (throwable != null) {
+					jobGraphWriter.removeJobGraph(jobGraph.getJobID());
+				}
+			}));
+		}
+
+		final CompletableFuture<Void> runSMFuture = runStream(jobGraph);
+		return runSMFuture.whenComplete(BiConsumerWithException.unchecked((Object ignored, Throwable throwable) -> {
 			if (throwable != null) {
 				jobGraphWriter.removeJobGraph(jobGraph.getJobID());
 			}
 		}));
+	}
+
+	private CompletableFuture<Void> runStream(JobGraph jobGraph) {
+
+		final CompletableFuture<StreamManagerRunner> streamManagerRunnerFuture = createStreamManagerRunner(jobGraph);
+
+		return streamManagerRunnerFuture
+			.thenApply(FunctionUtils.uncheckedFunction(this::startStreamManagerRunner))
+			.thenApply(FunctionUtils.nullFn())
+			.whenCompleteAsync(
+					(ignored, throwable) -> {
+					},
+					getMainThreadExecutor());
+
 	}
 
 	private CompletableFuture<Void> runJob(JobGraph jobGraph) {
@@ -390,6 +419,22 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
 			rpcService.getExecutor());
 	}
 
+	private CompletableFuture<StreamManagerRunner> createStreamManagerRunner(JobGraph jobGraph) {
+		final RpcService rpcService = getRpcService();
+		StreamManagerRunnerFactory streamManagerRunnerFactory = DefaultStreamManagerRunnerFactory.INSTANCE;
+		return CompletableFuture.supplyAsync(
+				CheckedSupplier.unchecked(() ->
+					streamManagerRunnerFactory.createStreamManagerRunner(
+							jobGraph,
+							configuration,
+							rpcService,
+							highAvailabilityServices,
+							heartbeatServices,
+							fatalErrorHandler
+					)),
+				rpcService.getExecutor());
+	}
+
 	private JobManagerRunner startJobManagerRunner(JobManagerRunner jobManagerRunner) throws Exception {
 		final JobID jobId = jobManagerRunner.getJobID();
 
@@ -423,6 +468,11 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
 		jobManagerRunner.start();
 
 		return jobManagerRunner;
+	}
+
+	private StreamManagerRunner startStreamManagerRunner(StreamManagerRunner streamManagerRunner) throws Exception {
+		streamManagerRunner.start();
+		return streamManagerRunner;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -1015,10 +1015,6 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		slotPool.disconnectResourceManager();
 	}
 
-	//----------------------------------------------------------------------------------------------
-	// Service methods
-	//----------------------------------------------------------------------------------------------
-
 	@Override
 	public JobMasterGateway getGateway() {
 		return getSelfGateway(JobMasterGateway.class);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/StreamManagerDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/StreamManagerDispatcherTest.java
@@ -1,0 +1,289 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
+import org.apache.flink.runtime.controlplane.streammanager.StreamManager;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmanager.JobGraphWriter;
+import org.apache.flink.runtime.jobmaster.*;
+import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
+import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
+import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.rpc.TestingRpcService;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.runtime.util.TestingFatalErrorHandler;
+import org.apache.flink.util.TestLogger;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * !!! Set the flag TEST_FLAG in {@link Dispatcher} to test StreamManager. !!!
+ *
+ * Test for the {@link StreamManager} component.
+ */
+public class StreamManagerDispatcherTest extends TestLogger {
+
+	private static RpcService rpcService;
+
+	private static final Time TIMEOUT = Time.seconds(10L);
+
+	private static final Time INFINITY = RpcUtils.INF_TIMEOUT;
+
+	private static final JobID TEST_JOB_ID = new JobID();
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Rule
+	public TestName name = new TestName();
+
+	private JobGraph jobGraph;
+
+	private TestingFatalErrorHandler fatalErrorHandler;
+
+	private TestingLeaderElectionService jobMasterLeaderElectionService;
+
+	private CountDownLatch createdJobManagerRunnerLatch;
+
+	private Configuration configuration;
+
+	private BlobServer blobServer;
+
+	/** Instance under test. */
+	private TestingDispatcher dispatcher;
+
+	private TestingHighAvailabilityServices haServices;
+
+	private HeartbeatServices heartbeatServices;
+
+	@BeforeClass
+	public static void setupClass() {
+		rpcService = new TestingRpcService();
+	}
+
+	@AfterClass
+	public static void teardownClass() throws Exception {
+		if (rpcService != null) {
+			RpcUtils.terminateRpcService(rpcService, TIMEOUT);
+
+			rpcService = null;
+		}
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		final JobVertex testVertex = new JobVertex("testVertex");
+		testVertex.setInvokableClass(NoOpInvokable.class);
+		jobGraph = new JobGraph(TEST_JOB_ID, "testJob", testVertex);
+
+		fatalErrorHandler = new TestingFatalErrorHandler();
+		heartbeatServices = new HeartbeatServices(1000L, 10000L);
+
+		jobMasterLeaderElectionService = new TestingLeaderElectionService();
+
+		haServices = new TestingHighAvailabilityServices();
+		haServices.setJobMasterLeaderElectionService(TEST_JOB_ID, jobMasterLeaderElectionService);
+		haServices.setCheckpointRecoveryFactory(new StandaloneCheckpointRecoveryFactory());
+		haServices.setResourceManagerLeaderRetriever(new SettableLeaderRetrievalService());
+
+		configuration = new Configuration();
+
+		configuration.setString(
+			BlobServerOptions.STORAGE_DIRECTORY,
+			temporaryFolder.newFolder().getAbsolutePath());
+
+		createdJobManagerRunnerLatch = new CountDownLatch(2);
+		blobServer = new BlobServer(configuration, new VoidBlobStore());
+	}
+
+	@Nonnull
+	private TestingDispatcher createAndStartDispatcher(
+			HeartbeatServices heartbeatServices,
+			TestingHighAvailabilityServices haServices,
+			JobManagerRunnerFactory jobManagerRunnerFactory) throws Exception {
+		final TestingDispatcher dispatcher = new TestingDispatcherBuilder()
+			.setHaServices(haServices)
+			.setHeartbeatServices(heartbeatServices)
+			.setJobManagerRunnerFactory(jobManagerRunnerFactory)
+			.build();
+		dispatcher.start();
+
+		return dispatcher;
+	}
+
+	private class TestingDispatcherBuilder {
+
+		private Collection<JobGraph> initialJobGraphs = Collections.emptyList();
+
+		private HeartbeatServices heartbeatServices = StreamManagerDispatcherTest.this.heartbeatServices;
+
+		private HighAvailabilityServices haServices = StreamManagerDispatcherTest.this.haServices;
+
+		private JobManagerRunnerFactory jobManagerRunnerFactory = DefaultJobManagerRunnerFactory.INSTANCE;
+
+		private JobGraphWriter jobGraphWriter = NoOpJobGraphWriter.INSTANCE;
+
+		TestingDispatcherBuilder setHeartbeatServices(HeartbeatServices heartbeatServices) {
+			this.heartbeatServices = heartbeatServices;
+			return this;
+		}
+
+		TestingDispatcherBuilder setHaServices(HighAvailabilityServices haServices) {
+			this.haServices = haServices;
+			return this;
+		}
+
+		TestingDispatcherBuilder setInitialJobGraphs(Collection<JobGraph> initialJobGraphs) {
+			this.initialJobGraphs = initialJobGraphs;
+			return this;
+		}
+
+		TestingDispatcherBuilder setJobManagerRunnerFactory(JobManagerRunnerFactory jobManagerRunnerFactory) {
+			this.jobManagerRunnerFactory = jobManagerRunnerFactory;
+			return this;
+		}
+
+		TestingDispatcherBuilder setJobGraphWriter(JobGraphWriter jobGraphWriter) {
+			this.jobGraphWriter = jobGraphWriter;
+			return this;
+		}
+
+		TestingDispatcher build() throws Exception {
+			TestingResourceManagerGateway resourceManagerGateway = new TestingResourceManagerGateway();
+
+			final MemoryArchivedExecutionGraphStore archivedExecutionGraphStore = new MemoryArchivedExecutionGraphStore();
+
+			return new TestingDispatcher(
+				rpcService,
+				Dispatcher.DISPATCHER_NAME + '_' + name.getMethodName(),
+				DispatcherId.generate(),
+				initialJobGraphs,
+				new DispatcherServices(
+					configuration,
+					haServices,
+					() -> CompletableFuture.completedFuture(resourceManagerGateway),
+					blobServer,
+					heartbeatServices,
+					archivedExecutionGraphStore,
+					fatalErrorHandler,
+					VoidHistoryServerArchivist.INSTANCE,
+					null,
+					UnregisteredMetricGroups.createUnregisteredJobManagerMetricGroup(),
+					jobGraphWriter,
+					jobManagerRunnerFactory));
+		}
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		try {
+			fatalErrorHandler.rethrowError();
+		} finally {
+			if (dispatcher != null) {
+				RpcUtils.terminateRpcEndpoint(dispatcher, TIMEOUT);
+			}
+		}
+
+		if (haServices != null) {
+			haServices.closeAndCleanupAllData();
+		}
+
+		if (blobServer != null) {
+			blobServer.close();
+		}
+	}
+
+	/**
+	 * Tests that we can submit a job to the Dispatcher which then spawns a
+	 * new JobManagerRunner.
+	 */
+	@Test
+	public void testStreamManager() throws Exception {
+		dispatcher = createAndStartDispatcher(heartbeatServices, haServices, new ExpectedJobIdJobManagerRunnerFactory(TEST_JOB_ID, createdJobManagerRunnerLatch));
+
+		DispatcherGateway dispatcherGateway = dispatcher.getSelfGateway(DispatcherGateway.class);
+
+		CompletableFuture<Acknowledge> acknowledgeFuture = dispatcherGateway.submitJob(jobGraph, INFINITY);
+
+		assertEquals(acknowledgeFuture.get(), Acknowledge.get());
+	}
+
+	private static final class ExpectedJobIdJobManagerRunnerFactory implements JobManagerRunnerFactory {
+
+		private final JobID expectedJobId;
+
+		private final CountDownLatch createdJobManagerRunnerLatch;
+
+		private ExpectedJobIdJobManagerRunnerFactory(JobID expectedJobId, CountDownLatch createdJobManagerRunnerLatch) {
+			this.expectedJobId = expectedJobId;
+			this.createdJobManagerRunnerLatch = createdJobManagerRunnerLatch;
+		}
+
+		@Override
+		public JobManagerRunner createJobManagerRunner(
+				JobGraph jobGraph,
+				Configuration configuration,
+				RpcService rpcService,
+				HighAvailabilityServices highAvailabilityServices,
+				HeartbeatServices heartbeatServices,
+				JobManagerSharedServices jobManagerSharedServices,
+				JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
+				FatalErrorHandler fatalErrorHandler) throws Exception {
+			assertEquals(expectedJobId, jobGraph.getJobID());
+
+			createdJobManagerRunnerLatch.countDown();
+
+			return DefaultJobManagerRunnerFactory.INSTANCE.createJobManagerRunner(
+				jobGraph,
+				configuration,
+				rpcService,
+				highAvailabilityServices,
+				heartbeatServices,
+				jobManagerSharedServices,
+				jobManagerJobMetricGroupFactory,
+				fatalErrorHandler);
+		}
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingStreamDispatcher.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingStreamDispatcher.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.rpc.RpcService;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+/**
+ * {@link Dispatcher} implementation used for testing purposes.
+ */
+class TestingStreamDispatcher extends Dispatcher {
+
+	private final CompletableFuture<Void> startFuture;
+
+	TestingStreamDispatcher(
+			RpcService rpcService,
+			String endpointId,
+			DispatcherId fencingToken,
+			Collection<JobGraph> recoveredJobs,
+			DispatcherServices dispatcherServices) throws Exception {
+		super(
+			rpcService,
+			endpointId,
+			fencingToken,
+			recoveredJobs,
+			dispatcherServices);
+
+		this.startFuture = new CompletableFuture<>();
+	}
+
+
+
+	@Override
+	public void onStart() throws Exception {
+		try {
+			super.onStart();
+		} catch (Exception e) {
+			startFuture.completeExceptionally(e);
+			throw e;
+		}
+
+		startFuture.complete(null);
+	}
+
+	void completeJobExecution(ArchivedExecutionGraph archivedExecutionGraph) {
+		runAsync(
+			() -> jobReachedGloballyTerminalState(archivedExecutionGraph));
+	}
+
+	CompletableFuture<Void> getJobTerminationFuture(@Nonnull JobID jobId, @Nonnull Time timeout) {
+		return callAsyncWithoutFencing(
+			() -> getJobTerminationFuture(jobId),
+			timeout).thenCompose(Function.identity());
+	}
+
+	CompletableFuture<Integer> getNumberJobs(Time timeout) {
+		return callAsyncWithoutFencing(
+			() -> listJobs(timeout).get().size(),
+			timeout);
+	}
+
+	void waitUntilStarted() {
+		startFuture.join();
+	}
+}

--- a/flink-runtime/src/test/resources/log4j-test.properties
+++ b/flink-runtime/src/test/resources/log4j-test.properties
@@ -18,7 +18,7 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-log4j.rootLogger=OFF, testlogger
+log4j.rootLogger=DEBUG, testlogger
 
 # testlogger is set to be a ConsoleAppender.
 log4j.appender.testlogger=org.apache.log4j.ConsoleAppender


### PR DESCRIPTION
<!--
这个模板是我根据flink官方提供的pull request的模板适配的。
尽量根据这个pull request模板附上pull request的信息吧！
-->

## What is the purpose of the change

This pull request initialize the StreamManager in a procedure that initialize the JobManager.

Close #3 

## Brief change log

1. rename StreamMaster to StreamManager
2. create necessary classes to initialize StreamManager
3. write `StreamManagerDispatcherTest.java` to validate
4. change test logging level from OFF to DEBUG
5. !!! Modify the `runtime.dispatcher.TEST_FLAG` !!!
    - to false for compile
    - to true for test
6. left lots of TODOs

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)

## One More Thing

Below are the logging result while running the `StreamManagerDispatcherTest.java`:
1. with `TEST_FLAG` set to `true`, and line 444 and 445 show the initialization info for StreamManager
```
================================================================================
Test testStreamManager(org.apache.flink.runtime.dispatcher.StreamManagerDispatcherTest) is running.
--------------------------------------------------------------------------------
209  [main] INFO  org.apache.flink.runtime.blob.BlobServer  - Created BLOB server storage directory /var/folders/7y/31bgr_m103sgjq41bs6b7r_m0000gq/T/junit4342953660545698679/junit7871117991299759728/blobStore-7166c29c-ca9b-4b29-be34-2e3cdbbda0c0
224  [main] DEBUG org.apache.flink.util.NetUtils  - Trying to open socket on port 0
225  [main] INFO  org.apache.flink.runtime.blob.BlobServer  - Started BLOB server at 0.0.0.0:61269 - max concurrent requests: 50 - max backlog: 1000
300  [main] INFO  org.apache.flink.runtime.rpc.akka.AkkaRpcService  - Starting RPC endpoint for org.apache.flink.runtime.dispatcher.TestingDispatcher at akka://flink/user/dispatcher_testStreamManager .
417  [flink-akka.actor.default-dispatcher-2] INFO  org.apache.flink.runtime.dispatcher.TestingDispatcher  - Received JobGraph submission ce570c2546ac89f1f8bc98328e06d5c8 (testJob).
418  [flink-akka.actor.default-dispatcher-2] INFO  org.apache.flink.runtime.dispatcher.TestingDispatcher  - Submitting job ce570c2546ac89f1f8bc98328e06d5c8 (testJob).
442  [flink-akka.actor.default-dispatcher-4] INFO  org.apache.flink.runtime.rpc.akka.AkkaRpcService  - Starting RPC endpoint for org.apache.flink.runtime.controlplane.streammanager.StreamManager at akka://flink/user/streammanager_0 .
444  [flink-akka.actor.default-dispatcher-4] DEBUG org.apache.flink.runtime.controlplane.streammanager.StreamManager  - Initializing sm for job testJob (ce570c2546ac89f1f8bc98328e06d5c8)
445  [flink-akka.actor.default-dispatcher-4] DEBUG org.apache.flink.runtime.controlplane.streammanager.StreamManagerRunnerImpl  - StreamManager runner for job testJob (ce570c2546ac89f1f8bc98328e06d5c8) was granted leadership with session id 00000000-0000-0000-0000-000000000000 at akka://flink/user/streammanager_0.
455  [flink-akka.actor.default-dispatcher-4] INFO  org.apache.flink.runtime.dispatcher.TestingDispatcher  - Stopping dispatcher akka://flink/user/dispatcher_testStreamManager.
455  [flink-akka.actor.default-dispatcher-4] INFO  org.apache.flink.runtime.dispatcher.TestingDispatcher  - Stopping all currently running jobs of dispatcher akka://flink/user/dispatcher_testStreamManager.
459  [flink-akka.actor.default-dispatcher-4] INFO  org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureRequestCoordinator  - Shutting down back pressure request coordinator.
459  [flink-akka.actor.default-dispatcher-4] INFO  org.apache.flink.runtime.dispatcher.TestingDispatcher  - Stopped dispatcher akka://flink/user/dispatcher_testStreamManager.
487  [main] INFO  org.apache.flink.runtime.blob.BlobServer  - Stopped BLOB server at 0.0.0.0:61269
488  [main] INFO  org.apache.flink.runtime.dispatcher.StreamManagerDispatcherTest  - 
--------------------------------------------------------------------------------
Test testStreamManager(org.apache.flink.runtime.dispatcher.StreamManagerDispatcherTest) successfully run.
================================================================================
```
2. to false
```
================================================================================
Test testStreamManager(org.apache.flink.runtime.dispatcher.StreamManagerDispatcherTest) is running.
--------------------------------------------------------------------------------
200  [main] INFO  org.apache.flink.runtime.blob.BlobServer  - Created BLOB server storage directory /var/folders/7y/31bgr_m103sgjq41bs6b7r_m0000gq/T/junit7904487758655443131/junit6204052733111842012/blobStore-1fa56efc-7b33-4ccc-9cfd-b01de6d42dac
213  [main] DEBUG org.apache.flink.util.NetUtils  - Trying to open socket on port 0
215  [main] INFO  org.apache.flink.runtime.blob.BlobServer  - Started BLOB server at 0.0.0.0:61361 - max concurrent requests: 50 - max backlog: 1000
257  [main] INFO  org.apache.flink.runtime.rpc.akka.AkkaRpcService  - Starting RPC endpoint for org.apache.flink.runtime.dispatcher.TestingDispatcher at akka://flink/user/dispatcher_testStreamManager .
349  [flink-akka.actor.default-dispatcher-2] INFO  org.apache.flink.runtime.dispatcher.TestingDispatcher  - Received JobGraph submission 506427b71d52dab8651be37606bd1229 (testJob).
349  [flink-akka.actor.default-dispatcher-2] INFO  org.apache.flink.runtime.dispatcher.TestingDispatcher  - Submitting job 506427b71d52dab8651be37606bd1229 (testJob).
405  [flink-akka.actor.default-dispatcher-3] INFO  org.apache.flink.runtime.rpc.akka.AkkaRpcService  - Starting RPC endpoint for org.apache.flink.runtime.jobmaster.JobMaster at akka://flink/user/jobmanager_0 .
421  [flink-akka.actor.default-dispatcher-3] INFO  org.apache.flink.runtime.jobmaster.JobMaster  - Initializing job testJob (506427b71d52dab8651be37606bd1229).
465  [flink-akka.actor.default-dispatcher-3] INFO  org.apache.flink.runtime.jobmaster.JobMaster  - Using restart back off time strategy NoRestartBackoffTimeStrategy for testJob (506427b71d52dab8651be37606bd1229).
548  [flink-akka.actor.default-dispatcher-3] INFO  org.apache.flink.runtime.jobmaster.JobMaster  - Running initialization on master for job testJob (506427b71d52dab8651be37606bd1229).
548  [flink-akka.actor.default-dispatcher-3] INFO  org.apache.flink.runtime.jobmaster.JobMaster  - Successfully ran initialization on master in 0 ms.
549  [flink-akka.actor.default-dispatcher-3] DEBUG org.apache.flink.runtime.jobmaster.JobMaster  - Adding 1 vertices from job graph testJob (506427b71d52dab8651be37606bd1229).
549  [flink-akka.actor.default-dispatcher-3] DEBUG org.apache.flink.runtime.executiongraph.ExecutionGraph  - Attaching 1 topologically sorted vertices to existing job graph with 0 vertices and 0 intermediate results.
575  [flink-akka.actor.default-dispatcher-3] DEBUG org.apache.flink.runtime.executiongraph.ExecutionGraph  - Connecting ExecutionJobVertex 4489bda399cd112fe61462c4168ce339 (testVertex) to 0 predecessors.
593  [flink-akka.actor.default-dispatcher-3] DEBUG org.apache.flink.runtime.jobmaster.JobMaster  - Successfully created execution graph from job graph testJob (506427b71d52dab8651be37606bd1229).
598  [flink-akka.actor.default-dispatcher-3] INFO  org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionStrategy  - Start building failover regions.
598  [flink-akka.actor.default-dispatcher-3] DEBUG org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionStrategy  - Creating a failover region with 1 vertices.
599  [flink-akka.actor.default-dispatcher-3] INFO  org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionStrategy  - Created 1 failover regions.
599  [flink-akka.actor.default-dispatcher-3] INFO  org.apache.flink.runtime.jobmaster.JobMaster  - Using failover strategy org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionStrategy@5abc10db for testJob (506427b71d52dab8651be37606bd1229).
609  [flink-akka.actor.default-dispatcher-2] INFO  org.apache.flink.runtime.dispatcher.TestingDispatcher  - Stopping dispatcher akka://flink/user/dispatcher_testStreamManager.
609  [flink-akka.actor.default-dispatcher-2] INFO  org.apache.flink.runtime.dispatcher.TestingDispatcher  - Stopping all currently running jobs of dispatcher akka://flink/user/dispatcher_testStreamManager.
617  [flink-akka.actor.default-dispatcher-2] DEBUG org.apache.flink.runtime.dispatcher.TestingDispatcher  - There is a newer JobManagerRunner for the job 506427b71d52dab8651be37606bd1229.
619  [flink-akka.actor.default-dispatcher-4] INFO  org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureRequestCoordinator  - Shutting down back pressure request coordinator.
626  [flink-akka.actor.default-dispatcher-4] INFO  org.apache.flink.runtime.dispatcher.TestingDispatcher  - Stopped dispatcher akka://flink/user/dispatcher_testStreamManager.
635  [main] INFO  org.apache.flink.runtime.blob.BlobServer  - Stopped BLOB server at 0.0.0.0:61361
637  [main] INFO  org.apache.flink.runtime.dispatcher.StreamManagerDispatcherTest  - 
--------------------------------------------------------------------------------
Test testStreamManager(org.apache.flink.runtime.dispatcher.StreamManagerDispatcherTest) successfully run.
================================================================================
```