### PR TITLE
solve japicmp incompatible exception

### DIFF
--- a/flink-streaming-java/pom.xml
+++ b/flink-streaming-java/pom.xml
@@ -95,10 +95,10 @@ under the License.
 		<plugins>
 
 			<!-- activate API compatibility checks -->
-<!--			<plugin>-->
-<!--				<groupId>com.github.siom79.japicmp</groupId>-->
-<!--				<artifactId>japicmp-maven-plugin</artifactId>-->
-<!--			</plugin>-->
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+			</plugin>
 
 			<!-- disable fork reuse for the streaming project, because of
 			incorrect declaration of tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -1896,6 +1896,7 @@ under the License.
 								<exclude>org.apache.flink.streaming.api.environment.LegacyLocalStreamEnvironment</exclude>
 								<exclude>org.apache.flink.streaming.api.functions.sink.RichSinkFunction#invoke(java.lang.Object)</exclude>
 								<exclude>org.apache.flink.streaming.api.functions.sink.SinkFunction</exclude>
+								<exclude>org.apache.flink.streaming.api.operators.StreamOperator</exclude>
 								<exclude>org.apache.flink.api.java.hadoop.mapred.HadoopInputFormat</exclude>
 								<exclude>org.apache.flink.api.java.hadoop.mapred.HadoopOutputFormat</exclude>
 								<exclude>org.apache.flink.api.java.hadoop.mapreduce.HadoopInputFormat</exclude>


### PR DESCRIPTION
## What is the purpose of the change

Close #41 japicmp incompatible exception

## Brief changelog

1. uncomment the japicmp dependency
2. add <exclude>file name</exclude> in build.plugins.japicmp.configuration
