### PR TITLE
Graph rescale

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -14,8 +14,10 @@
 # limitations under the License.
 
 cd flink-core || exit
-mvn clean install -Dcheckstyle.skip -DskipTests -Dmaven.javadoc.skip
+mvn clean install -Dcheckstyle.skip -DskipTests -Dmaven.javadoc.skip -Drat.skip=true
 cd ../flink-runtime || exit
-mvn clean install -Dcheckstyle.skip -DskipTests -Dmaven.javadoc.skip
+mvn clean install -Dcheckstyle.skip -DskipTests -Dmaven.javadoc.skip -Drat.skip=true
 cd ../flink-streaming-java || exit
-mvn clean install -Dcheckstyle.skip -DskipTests -Dmaven.javadoc.skip
+mvn clean install -Dcheckstyle.skip -DskipTests -Dmaven.javadoc.skip -Drat.skip=true
+cd ../flink-clients || exit
+mvn clean install -Dcheckstyle.skip -DskipTests -Dmaven.javadoc.skip -Drat.skip=true

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerGateway.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.registration.RegistrationResponse;
+import org.apache.flink.runtime.rescale.JobRescaleAction;
 import org.apache.flink.runtime.rescale.JobRescalePartitionAssignment;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
@@ -64,8 +65,6 @@ public interface StreamManagerGateway extends FencedRpcGateway<StreamManagerId> 
 		final JobID jobId,
 		final Exception cause);
 
-	void rescaleStreamJob(JobVertexID vertexID, int parallelism, JobRescalePartitionAssignment jobRescalePartitionAssignment);
-
-	void repartitionStreamJob(JobVertexID vertexID, int parallelism, JobRescalePartitionAssignment jobRescalePartitionAssignment);
+	void rescaleStreamJob(JobRescaleAction.RescaleParamsWrapper wrapper);
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerGateway.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.controlplane.streammanager;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
@@ -35,7 +36,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * rpc gateway interface
  */
-public interface StreamManagerGateway extends FencedRpcGateway<StreamManagerId> {
+public interface StreamManagerGateway extends FencedRpcGateway<StreamManagerId>, JobStatusListener {
 
 	/**
 	 * Register a {@link JobMaster} at the resource manager.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerGateway.java
@@ -68,4 +68,11 @@ public interface StreamManagerGateway extends FencedRpcGateway<StreamManagerId>,
 
 	void rescaleStreamJob(JobRescaleAction.RescaleParamsWrapper wrapper);
 
+	/**
+	 * The notification from the JobManager that changes completed:
+	 * Maybe 1. Assign states for repartition, 2. Rescale and assign states
+	 * @param targetVertexID the JobVertexID of target vertex
+	 */
+	void streamSwitchComplete(JobVertexID targetVertexID);
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerGateway.java
@@ -21,9 +21,11 @@ package org.apache.flink.runtime.controlplane.streammanager;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.registration.RegistrationResponse;
+import org.apache.flink.runtime.rescale.JobRescalePartitionAssignment;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 
@@ -49,6 +51,7 @@ public interface StreamManagerGateway extends FencedRpcGateway<StreamManagerId> 
 		ResourceID jobMasterResourceId,
 		String jobMasterAddress,
 		JobID jobId,
+		ClassLoader userLoader,
 		@RpcTimeout Time timeout);
 
 	/**
@@ -60,5 +63,9 @@ public interface StreamManagerGateway extends FencedRpcGateway<StreamManagerId> 
 	void disconnectJobManager(
 		final JobID jobId,
 		final Exception cause);
+
+	void rescaleStreamJob(JobVertexID vertexID, int parallelism, JobRescalePartitionAssignment jobRescalePartitionAssignment);
+
+	void repartitionStreamJob(JobVertexID vertexID, int parallelism, JobRescalePartitionAssignment jobRescalePartitionAssignment);
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/controlplane/streammanager/StreamManagerGateway.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.controlplane.streammanager;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
@@ -36,7 +37,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * rpc gateway interface
  */
-public interface StreamManagerGateway extends FencedRpcGateway<StreamManagerId>, JobStatusListener {
+public interface StreamManagerGateway extends FencedRpcGateway<StreamManagerId> {
 
 	/**
 	 * Register a {@link JobMaster} at the resource manager.
@@ -73,6 +74,18 @@ public interface StreamManagerGateway extends FencedRpcGateway<StreamManagerId>,
 	 * Maybe 1. Assign states for repartition, 2. Rescale and assign states
 	 * @param targetVertexID the JobVertexID of target vertex
 	 */
-	void streamSwitchComplete(JobVertexID targetVertexID);
+	void streamSwitchCompleted(JobVertexID targetVertexID);
 
+	/**
+	 * This method is called whenever the status of the job changes.
+	 *
+	 * @param jobId         The ID of the job.
+	 * @param newJobStatus  The status the job switched to.
+	 * @param timestamp     The timestamp when the status transition occurred.
+	 * @param error         In case the job status switches to a failure state, this is the
+	 *                      exception that caused the failure.
+	 */
+	void jobStatusChanged(JobID jobId, JobStatus newJobStatus, long timestamp, Throwable error);
+
+//	void notifyStreamSwitchComplete(JobVertexID jobVertexId);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -308,11 +308,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 			jobManagerJobMetricGroup,
 			jobMasterConfiguration.getSlotRequestTimeout(),
 			shuffleMaster,
-			partitionTracker,
-			wrapper -> {
-				checkState(currentStreamManagerGateway != null, "do not have stream manager gateway");
-				currentStreamManagerGateway.rescaleStreamJob(wrapper);
-			});
+			partitionTracker);
 	}
 
 	//----------------------------------------------------------------------------------------------
@@ -947,6 +943,9 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 			final ArchivedExecutionGraph archivedExecutionGraph = schedulerNG.requestJob();
 			scheduledExecutorService.execute(() -> jobCompletionActions.jobReachedGloballyTerminalState(archivedExecutionGraph));
+			//todo notify upper stream manager or make sm periodly check job status?
+			checkState(currentStreamManagerGateway != null, "do not have stream manager gateway");
+			this.currentStreamManagerGateway.jobStatusChanges(jobGraph.getJobID(), newJobStatus, timestamp, error);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -1136,8 +1136,8 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 
 		@Override
-		public void streamManagerGainedLeadership(JobID jobId, StreamManagerGateway streamManagerGateway, JMTMRegistrationSuccess registrationMessage) {
-			runAsync(() -> log.info("a new stream mamanger gained Leadership"));
+		public void streamManagerGainedLeadership(JobID jobId, StreamManagerGateway streamManagerGateway, JobMasterRegistrationSuccess registrationMessage) {
+			log.info("a new stream manager gained Leadership:" + streamManagerGateway.toString());
 			currentStreamManagerGateway = streamManagerGateway;
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -481,6 +481,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		validateRunsInMainThread();
 
 		JobRescaleCoordinator rescaleCoordinator = this.schedulerNG.getJobRescaleCoordinator();
+		rescaleCoordinator.setJobManagerGateway(this); // pass JobMasterGateway to JobRescaleCoordinator
 		switch (wrapper.type) {
 			case REPARTITION:
 				rescaleCoordinator.repartition(wrapper.vertexID, wrapper.jobRescalePartitionAssignment,
@@ -495,6 +496,13 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 					involvedUpStream, involvedDownStream);
 				break;
 		}
+	}
+
+	@Override
+	public void notifyStreamSwitchComplete(JobVertexID targetVertexID) {
+		checkNotNull(targetVertexID, "The targetVertexID is null. (jobMaster.notifyStreamSwitchComplete) ");
+		checkNotNull(currentStreamManagerGateway, "The currentStreamManagerGateway is null.");
+		currentStreamManagerGateway.streamSwitchComplete(targetVertexID);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
@@ -274,14 +275,14 @@ public interface JobMasterGateway extends
 	CompletableFuture<Object> updateGlobalAggregate(String aggregateName, Object aggregand, byte[] serializedAggregationFunction);
 
 	void triggerJobRescale(
-			JobRescaleAction.RescaleParamsWrapper wrapper,
-			List<JobVertexID> involvedUpStream,
-			List<JobVertexID> involvedDownStream);
+		JobRescaleAction.RescaleParamsWrapper wrapper,
+		JobGraph jobGraph, List<JobVertexID> involvedUpStream,
+		List<JobVertexID> involvedDownStream);
 
 	/**
 	 * Notify StreamManager's StreamSwitchAdaptor that changes completed:
 	 * Maybe 1. Assign states for repartition, 2. Rescale and assign states
 	 * @param targetVertexID the JobVertexID of target vertex
 	 */
-	void notifyStreamSwitchComplete(JobVertexID targetVertexID);
+//	void notifyStreamSwitchComplete(JobVertexID targetVertexID);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -277,4 +277,11 @@ public interface JobMasterGateway extends
 			JobRescaleAction.RescaleParamsWrapper wrapper,
 			List<JobVertexID> involvedUpStream,
 			List<JobVertexID> involvedDownStream);
+
+	/**
+	 * Notify StreamManager's StreamSwitchAdaptor that changes completed:
+	 * Maybe 1. Assign states for repartition, 2. Rescale and assign states
+	 * @param targetVertexID the JobVertexID of target vertex
+	 */
+	void notifyStreamSwitchComplete(JobVertexID targetVertexID);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.registration.RegistrationResponse;
+import org.apache.flink.runtime.rescale.JobRescaleAction;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStatsResponse;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
@@ -48,6 +49,7 @@ import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import javax.annotation.Nullable;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -270,4 +272,9 @@ public interface JobMasterGateway extends
 	 * @return The updated aggregate
 	 */
 	CompletableFuture<Object> updateGlobalAggregate(String aggregateName, Object aggregand, byte[] serializedAggregationFunction);
+
+	void triggerJobRescale(
+			JobRescaleAction.RescaleParamsWrapper wrapper,
+			List<JobVertexID> involvedUpStream,
+			List<JobVertexID> involvedDownStream);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/streaming/StreamingLeaderListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/streaming/StreamingLeaderListener.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.controlplane.streammanager.StreamManagerGateway;
 import org.apache.flink.runtime.controlplane.streammanager.StreamManagerId;
 import org.apache.flink.runtime.jobmaster.JMTMRegistrationSuccess;
+import org.apache.flink.runtime.jobmaster.JobMasterRegistrationSuccess;
 import org.apache.flink.runtime.taskexecutor.JobLeaderService;
 
 /**
@@ -40,7 +41,7 @@ public interface StreamingLeaderListener {
 	 * @param streamManagerGateway to the job leader
 	 * @param registrationMessage containing further registration information
 	 */
-	void streamManagerGainedLeadership(JobID jobId, StreamManagerGateway streamManagerGateway, JMTMRegistrationSuccess registrationMessage);
+	void streamManagerGainedLeadership(JobID jobId, StreamManagerGateway streamManagerGateway, JobMasterRegistrationSuccess registrationMessage);
 
 	/**
 	 * Callback if the job leader for the job with the given job id lost its leadership.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/streaming/StreamingLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/streaming/StreamingLeaderService.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.controlplane.streammanager.StreamManagerId;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.jobmaster.JMTMRegistrationSuccess;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.JobMasterRegistrationSuccess;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.registration.RegisteredRpcConnection;
@@ -254,7 +255,7 @@ public class StreamingLeaderService {
 		 */
 		@GuardedBy("lock")
 		@Nullable
-		private RegisteredRpcConnection<StreamManagerId, StreamManagerGateway, JMTMRegistrationSuccess> rpcConnection;
+		private RegisteredRpcConnection<StreamManagerId, StreamManagerGateway, JobMasterRegistrationSuccess> rpcConnection;
 
 		/**
 		 * Leader id of the current job leader.
@@ -385,7 +386,7 @@ public class StreamingLeaderService {
 		/**
 		 * Rpc connection for the job manager <--> task manager connection.
 		 */
-		private final class StreamManagerRegisteredRpcConnection extends RegisteredRpcConnection<StreamManagerId, StreamManagerGateway, JMTMRegistrationSuccess> {
+		private final class StreamManagerRegisteredRpcConnection extends RegisteredRpcConnection<StreamManagerId, StreamManagerGateway, JobMasterRegistrationSuccess> {
 			private final JobMasterInfo jobMasterInfo;
 
 			StreamManagerRegisteredRpcConnection(
@@ -399,7 +400,7 @@ public class StreamingLeaderService {
 			}
 
 			@Override
-			protected RetryingRegistration<StreamManagerId, StreamManagerGateway, JMTMRegistrationSuccess> generateRegistration() {
+			protected RetryingRegistration<StreamManagerId, StreamManagerGateway, JobMasterRegistrationSuccess> generateRegistration() {
 				return new StreamManagerRetryingRegistration(
 					LOG,
 					rpcService,
@@ -412,7 +413,7 @@ public class StreamingLeaderService {
 			}
 
 			@Override
-			protected void onRegistrationSuccess(JMTMRegistrationSuccess success) {
+			protected void onRegistrationSuccess(JobMasterRegistrationSuccess success) {
 				// filter out old registration attempts
 				if (Objects.equals(getTargetLeaderId(), getCurrentStreamManagerId())) {
 					log.info("Successful registration at job manager {} for job {}.", getTargetAddress(), jobId);
@@ -440,7 +441,7 @@ public class StreamingLeaderService {
 	 * Retrying registration for the job manager <--> task manager connection.
 	 */
 	private static final class StreamManagerRetryingRegistration
-		extends RetryingRegistration<StreamManagerId, StreamManagerGateway, JMTMRegistrationSuccess> {
+		extends RetryingRegistration<StreamManagerId, StreamManagerGateway, JobMasterRegistrationSuccess> {
 
 		private final JobMasterInfo jobMasterInfo;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rescale/JobGraphRescaler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rescale/JobGraphRescaler.java
@@ -18,10 +18,13 @@
 
 package org.apache.flink.runtime.rescale;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.lang.reflect.Constructor;
 import java.util.List;
 import java.util.Map;
@@ -29,16 +32,25 @@ import java.util.Map;
 public abstract class JobGraphRescaler {
 
 	protected final JobGraph jobGraph;
-	protected final ClassLoader userCodeLoader;
+	protected ClassLoader userCodeLoader;
 
-	public JobGraphRescaler(JobGraph jobGraph, ClassLoader userCodeLoader) {
+	public JobGraphRescaler(JobGraph jobGraph, @Nullable ClassLoader userCodeLoader) {
 		this.jobGraph = jobGraph;
 		this.userCodeLoader = userCodeLoader;
 	}
 
-	public abstract void rescale(JobVertexID id, int newParallelism, Map<Integer, List<Integer>> partitionAssignment, List<JobVertexID> involvedUpstream, List<JobVertexID> involvedDownstream);
+	public void setUserCodeLoader(@Nonnull ClassLoader userCodeLoader) {
+		this.userCodeLoader = userCodeLoader;
+	}
 
-	public abstract void repartition(JobVertexID id, Map<Integer, List<Integer>> partitionAssignment, List<JobVertexID> involvedUpstream, List<JobVertexID> involvedDownstream);
+	public abstract Tuple2<List<JobVertexID>, List<JobVertexID>> rescale(
+		JobVertexID id,
+		int newParallelism,
+		Map<Integer, List<Integer>> partitionAssignment);
+
+	public abstract Tuple2<List<JobVertexID>, List<JobVertexID>> repartition(
+		JobVertexID id,
+		Map<Integer, List<Integer>> partitionAssignment);
 
 	public abstract String print(Configuration config);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rescale/JobRescaleAction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rescale/JobRescaleAction.java
@@ -11,18 +11,21 @@ public interface JobRescaleAction {
 
 	void repartition(JobVertexID vertexID,
 					 JobRescalePartitionAssignment jobRescalePartitionAssignment,
+					 JobGraph jobGraph,
 					 List<JobVertexID> involvedUpStream,
 					 List<JobVertexID> involvedDownStream);
 
 	void scaleOut(JobVertexID vertexID,
 				  int newParallelism,
 				  JobRescalePartitionAssignment jobRescalePartitionAssignment,
+				  JobGraph jobGraph,
 				  List<JobVertexID> involvedUpStream,
 				  List<JobVertexID> involvedDownStream);
 
 	void scaleIn(JobVertexID vertexID,
 				 int newParallelism,
 				 JobRescalePartitionAssignment jobRescalePartitionAssignment,
+				 JobGraph jobGraph,
 				 List<JobVertexID> involvedUpStream,
 				 List<JobVertexID> involvedDownStream);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rescale/JobRescaleAction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rescale/JobRescaleAction.java
@@ -3,15 +3,28 @@ package org.apache.flink.runtime.rescale;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
+import java.util.List;
+
 public interface JobRescaleAction {
 
 	JobGraph getJobGraph();
 
-	void repartition(JobVertexID vertexID, JobRescalePartitionAssignment jobRescalePartitionAssignment);
+	void repartition(JobVertexID vertexID,
+					 JobRescalePartitionAssignment jobRescalePartitionAssignment,
+					 List<JobVertexID> involvedUpStream,
+					 List<JobVertexID> involvedDownStream);
 
-	void scaleOut(JobVertexID vertexID, int newParallelism, JobRescalePartitionAssignment jobRescalePartitionAssignment);
+	void scaleOut(JobVertexID vertexID,
+				  int newParallelism,
+				  JobRescalePartitionAssignment jobRescalePartitionAssignment,
+				  List<JobVertexID> involvedUpStream,
+				  List<JobVertexID> involvedDownStream);
 
-	void scaleIn(JobVertexID vertexID, int newParallelism, JobRescalePartitionAssignment jobRescalePartitionAssignment);
+	void scaleIn(JobVertexID vertexID,
+				 int newParallelism,
+				 JobRescalePartitionAssignment jobRescalePartitionAssignment,
+				 List<JobVertexID> involvedUpStream,
+				 List<JobVertexID> involvedDownStream);
 
 	enum ActionType {
 		REPARTITION,
@@ -19,19 +32,20 @@ public interface JobRescaleAction {
 		SCALE_IN
 	}
 
-	default void parseParams(RescaleParamsWrapper wrapper) {
-		switch (wrapper.type) {
-			case REPARTITION:
-				repartition(wrapper.vertexID, wrapper.jobRescalePartitionAssignment);
-				break;
-			case SCALE_OUT:
-				scaleOut(wrapper.vertexID, wrapper.newParallelism, wrapper.jobRescalePartitionAssignment);
-				break;
-			case SCALE_IN:
-				scaleIn(wrapper.vertexID, wrapper.newParallelism, wrapper.jobRescalePartitionAssignment);
-				break;
-		}
-	}
+//	@Deprecated
+//	default void parseParams(RescaleParamsWrapper wrapper) {
+//		switch (wrapper.type) {
+//			case REPARTITION:
+//				repartition(wrapper.vertexID, wrapper.jobRescalePartitionAssignment);
+//				break;
+//			case SCALE_OUT:
+//				scaleOut(wrapper.vertexID, wrapper.newParallelism, wrapper.jobRescalePartitionAssignment);
+//				break;
+//			case SCALE_IN:
+//				scaleIn(wrapper.vertexID, wrapper.newParallelism, wrapper.jobRescalePartitionAssignment);
+//				break;
+//		}
+//	}
 
 	class RescaleParamsWrapper {
 
@@ -41,10 +55,10 @@ public interface JobRescaleAction {
 		public final JobRescalePartitionAssignment jobRescalePartitionAssignment;
 
 		public RescaleParamsWrapper(
-				ActionType type,
-				JobVertexID vertexID,
-				int newParallelism,
-				JobRescalePartitionAssignment jobRescalePartitionAssignment) {
+			ActionType type,
+			JobVertexID vertexID,
+			int newParallelism,
+			JobRescalePartitionAssignment jobRescalePartitionAssignment) {
 			this.type = type;
 			this.vertexID = vertexID;
 			this.newParallelism = newParallelism;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rescale/JobRescaleAction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rescale/JobRescaleAction.java
@@ -35,10 +35,10 @@ public interface JobRescaleAction {
 
 	class RescaleParamsWrapper {
 
-		final ActionType type;
-		final JobVertexID vertexID;
-		final int newParallelism;
-		final JobRescalePartitionAssignment jobRescalePartitionAssignment;
+		public final ActionType type;
+		public final JobVertexID vertexID;
+		public final int newParallelism;
+		public final JobRescalePartitionAssignment jobRescalePartitionAssignment;
 
 		public RescaleParamsWrapper(
 				ActionType type,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rescale/JobRescaleCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rescale/JobRescaleCoordinator.java
@@ -56,8 +56,6 @@ public class JobRescaleCoordinator implements JobRescaleAction, RescalepointAckn
 
 	private ComponentMainThreadExecutor mainThreadExecutor;
 
-	private FlinkStreamSwitchAdaptor streamSwitchAdaptor;
-
 	private final List<ExecutionAttemptID> notYetAcknowledgedTasks;
 
 	private JobStatusListener jobStatusListener;
@@ -87,16 +85,14 @@ public class JobRescaleCoordinator implements JobRescaleAction, RescalepointAckn
 
 	public JobRescaleCoordinator(
 			JobGraph jobGraph,
-			ExecutionGraph executionGraph,
-			ClassLoader userCodeLoader,
-			RescaleActionListener rescaleActionListener) {
+			ExecutionGraph executionGraph) {
 
 		this.jobGraph = jobGraph;
 		this.executionGraph = executionGraph;
 
 		this.notYetAcknowledgedTasks = new ArrayList<>();
 
-		this.streamSwitchAdaptor = new FlinkStreamSwitchAdaptor(this, executionGraph, rescaleActionListener);
+//		this.streamSwitchAdaptor = new FlinkStreamSwitchAdaptor(this, executionGraph, rescaleActionListener);
 //		this.jobGraphRescaler = JobGraphRescaler.instantiate(jobGraph, userCodeLoader);
 	}
 
@@ -105,11 +101,11 @@ public class JobRescaleCoordinator implements JobRescaleAction, RescalepointAckn
 	}
 
 	public void start() {
-		streamSwitchAdaptor.startControllers();
+//		streamSwitchAdaptor.startControllers();
 	}
 
 	public void stop() {
-		streamSwitchAdaptor.stopControllers();
+//		streamSwitchAdaptor.stopControllers();
 	}
 
 //	since this method is not used, I comment this method to avoid compiled error

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rescale/JobRescaleCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rescale/JobRescaleCoordinator.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.checkpoint.PendingCheckpoint;
 import org.apache.flink.runtime.checkpoint.StateAssignmentOperation;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.controlplane.streammanager.StreamManagerGateway;
 import org.apache.flink.runtime.executiongraph.*;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.api.common.JobStatus;
@@ -89,14 +90,15 @@ public class JobRescaleCoordinator implements JobRescaleAction, RescalepointAckn
 	public JobRescaleCoordinator(
 			JobGraph jobGraph,
 			ExecutionGraph executionGraph,
-			ClassLoader userCodeLoader) {
+			ClassLoader userCodeLoader,
+			RescaleActionListener rescaleActionListener) {
 
 		this.jobGraph = jobGraph;
 		this.executionGraph = executionGraph;
 
 		this.notYetAcknowledgedTasks = new ArrayList<>();
 
-		this.streamSwitchAdaptor = new FlinkStreamSwitchAdaptor(this, executionGraph);
+		this.streamSwitchAdaptor = new FlinkStreamSwitchAdaptor(this, executionGraph, rescaleActionListener);
 		this.jobGraphRescaler = JobGraphRescaler.instantiate(jobGraph, userCodeLoader);
 	}
 
@@ -179,6 +181,10 @@ public class JobRescaleCoordinator implements JobRescaleAction, RescalepointAckn
 		} catch (Exception e) {
 			failExecution(e);
 		}
+	}
+
+	private StreamManagerGateway getStreamManagerGateway(){
+		this.executionGraph.getCheckpointCoordinator().get
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rescale/RescaleActionListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rescale/RescaleActionListener.java
@@ -1,0 +1,5 @@
+package org.apache.flink.runtime.rescale;
+
+public interface RescaleActionListener {
+	void processRescaleParamsWrapper(JobRescaleAction.RescaleParamsWrapper wrapper);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rescale/RescaleActionListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rescale/RescaleActionListener.java
@@ -1,5 +1,0 @@
-package org.apache.flink.runtime.rescale;
-
-public interface RescaleActionListener {
-	void processRescaleParamsWrapper(JobRescaleAction.RescaleParamsWrapper wrapper);
-}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rescale/RescaleActionQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rescale/RescaleActionQueue.java
@@ -15,14 +15,17 @@ public class RescaleActionQueue extends Thread {
 
 	private final JobRescaleAction rescaleAction;
 
+	private final RescaleActionListener rescaleActionListener;
+
 	private final Queue<RescaleParamsWrapper> queue;
 
 	private boolean isFinished;
 
 	private volatile boolean isStop;
 
-	public RescaleActionQueue(JobRescaleAction rescaleAction) {
+	public RescaleActionQueue(JobRescaleAction rescaleAction, RescaleActionListener rescaleActionListener) {
 		this.rescaleAction = rescaleAction;
+		this.rescaleActionListener = rescaleActionListener;
 		this.queue = new LinkedList<>();
 	}
 
@@ -40,7 +43,8 @@ public class RescaleActionQueue extends Thread {
 					RescaleParamsWrapper wrapper = queue.poll();
 					if (wrapper != null) {
 						isFinished = false;
-						rescaleAction.parseParams(wrapper);
+//						rescaleAction.parseParams(wrapper);
+						rescaleActionListener.processRescaleParamsWrapper(wrapper);
 
 						while (!isFinished && !isStop) {
 							queue.wait(); // wait for finish
@@ -57,10 +61,10 @@ public class RescaleActionQueue extends Thread {
 	}
 
 	public void put(
-			JobRescaleAction.ActionType type,
-			JobVertexID vertexID,
-			int newParallelism,
-			JobRescalePartitionAssignment jobRescalePartitionAssignment) {
+		JobRescaleAction.ActionType type,
+		JobVertexID vertexID,
+		int newParallelism,
+		JobRescalePartitionAssignment jobRescalePartitionAssignment) {
 
 		put(new RescaleParamsWrapper(type, vertexID, newParallelism, jobRescalePartitionAssignment));
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rescale/streamswitch/FlinkStreamSwitchAdaptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rescale/streamswitch/FlinkStreamSwitchAdaptor.java
@@ -6,6 +6,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rescale.JobRescaleAction;
 import org.apache.flink.runtime.rescale.JobRescalePartitionAssignment;
+import org.apache.flink.runtime.rescale.RescaleActionListener;
 import org.apache.flink.runtime.rescale.RescaleActionQueue;
 import org.apache.flink.runtime.rescale.controller.OperatorControllerListener;
 import org.apache.flink.runtime.rescale.controller.OperatorController;
@@ -33,9 +34,10 @@ public class FlinkStreamSwitchAdaptor {
 
 	public FlinkStreamSwitchAdaptor(
 		JobRescaleAction rescaleAction,
-		ExecutionGraph executionGraph) {
+		ExecutionGraph executionGraph,
+		RescaleActionListener rescaleActionListener) {
 
-		this.actionQueue = new RescaleActionQueue(rescaleAction);
+		this.actionQueue = new RescaleActionQueue(rescaleAction, rescaleActionListener);
 
 		this.controllers = new HashMap<>(executionGraph.getAllVertices().size());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -40,7 +40,6 @@ import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableExceptio
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
-import org.apache.flink.runtime.rescale.RescaleActionListener;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.LazyFromSourcesSchedulingStrategy;
@@ -116,8 +115,7 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 		final RestartBackoffTimeStrategy restartBackoffTimeStrategy,
 		final ExecutionVertexOperations executionVertexOperations,
 		final ExecutionVertexVersioner executionVertexVersioner,
-		final ExecutionSlotAllocatorFactory executionSlotAllocatorFactory,
-		final RescaleActionListener rescaleActionListener) throws Exception {
+		final ExecutionSlotAllocatorFactory executionSlotAllocatorFactory) throws Exception {
 
 		super(
 			log,
@@ -137,8 +135,7 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 			shuffleMaster,
 			partitionTracker,
 			executionVertexVersioner,
-			false,
-			rescaleActionListener);
+			false);
 
 		this.log = log;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableExceptio
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
+import org.apache.flink.runtime.rescale.RescaleActionListener;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.LazyFromSourcesSchedulingStrategy;
@@ -115,7 +116,8 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 		final RestartBackoffTimeStrategy restartBackoffTimeStrategy,
 		final ExecutionVertexOperations executionVertexOperations,
 		final ExecutionVertexVersioner executionVertexVersioner,
-		final ExecutionSlotAllocatorFactory executionSlotAllocatorFactory) throws Exception {
+		final ExecutionSlotAllocatorFactory executionSlotAllocatorFactory,
+		final RescaleActionListener rescaleActionListener) throws Exception {
 
 		super(
 			log,
@@ -135,7 +137,8 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 			shuffleMaster,
 			partitionTracker,
 			executionVertexVersioner,
-			false);
+			false,
+			rescaleActionListener);
 
 		this.log = log;
 
@@ -321,10 +324,10 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 	}
 
 	private static Map<ExecutionVertexID, ExecutionVertexDeploymentOption> groupDeploymentOptionsByVertexId(
-			final Collection<ExecutionVertexDeploymentOption> executionVertexDeploymentOptions) {
+		final Collection<ExecutionVertexDeploymentOption> executionVertexDeploymentOptions) {
 		return executionVertexDeploymentOptions.stream().collect(Collectors.toMap(
-				ExecutionVertexDeploymentOption::getExecutionVertexId,
-				Function.identity()));
+			ExecutionVertexDeploymentOption::getExecutionVertexId,
+			Function.identity()));
 	}
 
 	private List<SlotExecutionVertexAssignment> allocateSlots(final List<ExecutionVertexDeploymentOption> executionVertexDeploymentOptions) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
+import org.apache.flink.runtime.rescale.RescaleActionListener;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
 import org.apache.flink.runtime.scheduler.strategy.EagerSchedulingStrategy;
 import org.apache.flink.runtime.scheduler.strategy.LazyFromSourcesSchedulingStrategy;
@@ -65,7 +66,8 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
 			final JobManagerJobMetricGroup jobManagerJobMetricGroup,
 			final Time slotRequestTimeout,
 			final ShuffleMaster<?> shuffleMaster,
-			final JobMasterPartitionTracker partitionTracker) throws Exception {
+			final JobMasterPartitionTracker partitionTracker,
+			final RescaleActionListener rescaleActionListener) throws Exception {
 
 		final SchedulingStrategyFactory schedulingStrategyFactory = createSchedulingStrategyFactory(jobGraph.getScheduleMode());
 		final RestartBackoffTimeStrategy restartBackoffTimeStrategy = RestartBackoffTimeStrategyFactoryLoader
@@ -106,7 +108,8 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
 			restartBackoffTimeStrategy,
 			new DefaultExecutionVertexOperations(),
 			new ExecutionVertexVersioner(),
-			new DefaultExecutionSlotAllocatorFactory(slotProviderStrategy));
+			new DefaultExecutionSlotAllocatorFactory(slotProviderStrategy),
+			rescaleActionListener);
 	}
 
 	private SchedulingStrategyFactory createSchedulingStrategyFactory(final ScheduleMode scheduleMode) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -33,7 +33,6 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
-import org.apache.flink.runtime.rescale.RescaleActionListener;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
 import org.apache.flink.runtime.scheduler.strategy.EagerSchedulingStrategy;
 import org.apache.flink.runtime.scheduler.strategy.LazyFromSourcesSchedulingStrategy;
@@ -66,8 +65,7 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
 			final JobManagerJobMetricGroup jobManagerJobMetricGroup,
 			final Time slotRequestTimeout,
 			final ShuffleMaster<?> shuffleMaster,
-			final JobMasterPartitionTracker partitionTracker,
-			final RescaleActionListener rescaleActionListener) throws Exception {
+			final JobMasterPartitionTracker partitionTracker) throws Exception {
 
 		final SchedulingStrategyFactory schedulingStrategyFactory = createSchedulingStrategyFactory(jobGraph.getScheduleMode());
 		final RestartBackoffTimeStrategy restartBackoffTimeStrategy = RestartBackoffTimeStrategyFactoryLoader
@@ -108,8 +106,7 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
 			restartBackoffTimeStrategy,
 			new DefaultExecutionVertexOperations(),
 			new ExecutionVertexVersioner(),
-			new DefaultExecutionSlotAllocatorFactory(slotProviderStrategy),
-			rescaleActionListener);
+			new DefaultExecutionSlotAllocatorFactory(slotProviderStrategy));
 	}
 
 	private SchedulingStrategyFactory createSchedulingStrategyFactory(final ScheduleMode scheduleMode) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
-import org.apache.flink.runtime.rescale.RescaleActionListener;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 
@@ -46,23 +45,22 @@ import java.util.concurrent.ScheduledExecutorService;
 public class LegacyScheduler extends SchedulerBase {
 
 	public LegacyScheduler(
-			final Logger log,
-			final JobGraph jobGraph,
-			final BackPressureStatsTracker backPressureStatsTracker,
-			final Executor ioExecutor,
-			final Configuration jobMasterConfiguration,
-			final SlotProvider slotProvider,
-			final ScheduledExecutorService futureExecutor,
-			final ClassLoader userCodeLoader,
-			final CheckpointRecoveryFactory checkpointRecoveryFactory,
-			final Time rpcTimeout,
-			final RestartStrategyFactory restartStrategyFactory,
-			final BlobWriter blobWriter,
-			final JobManagerJobMetricGroup jobManagerJobMetricGroup,
-			final Time slotRequestTimeout,
-			final ShuffleMaster<?> shuffleMaster,
-			final JobMasterPartitionTracker partitionTracker,
-			RescaleActionListener rescaleActionListener) throws Exception {
+		final Logger log,
+		final JobGraph jobGraph,
+		final BackPressureStatsTracker backPressureStatsTracker,
+		final Executor ioExecutor,
+		final Configuration jobMasterConfiguration,
+		final SlotProvider slotProvider,
+		final ScheduledExecutorService futureExecutor,
+		final ClassLoader userCodeLoader,
+		final CheckpointRecoveryFactory checkpointRecoveryFactory,
+		final Time rpcTimeout,
+		final RestartStrategyFactory restartStrategyFactory,
+		final BlobWriter blobWriter,
+		final JobManagerJobMetricGroup jobManagerJobMetricGroup,
+		final Time slotRequestTimeout,
+		final ShuffleMaster<?> shuffleMaster,
+		final JobMasterPartitionTracker partitionTracker) throws Exception {
 
 		super(
 			log,
@@ -82,8 +80,7 @@ public class LegacyScheduler extends SchedulerBase {
 			shuffleMaster,
 			partitionTracker,
 			new ExecutionVertexVersioner(),
-			true,
-			rescaleActionListener);
+			true);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
+import org.apache.flink.runtime.rescale.RescaleActionListener;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 
@@ -60,7 +61,8 @@ public class LegacyScheduler extends SchedulerBase {
 			final JobManagerJobMetricGroup jobManagerJobMetricGroup,
 			final Time slotRequestTimeout,
 			final ShuffleMaster<?> shuffleMaster,
-			final JobMasterPartitionTracker partitionTracker) throws Exception {
+			final JobMasterPartitionTracker partitionTracker,
+			RescaleActionListener rescaleActionListener) throws Exception {
 
 		super(
 			log,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacyScheduler.java
@@ -82,7 +82,8 @@ public class LegacyScheduler extends SchedulerBase {
 			shuffleMaster,
 			partitionTracker,
 			new ExecutionVertexVersioner(),
-			true);
+			true,
+			rescaleActionListener);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacySchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacySchedulerFactory.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
+import org.apache.flink.runtime.rescale.RescaleActionListener;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 
@@ -65,7 +66,8 @@ public class LegacySchedulerFactory implements SchedulerNGFactory {
 			final JobManagerJobMetricGroup jobManagerJobMetricGroup,
 			final Time slotRequestTimeout,
 			final ShuffleMaster<?> shuffleMaster,
-			final JobMasterPartitionTracker partitionTracker) throws Exception {
+			final JobMasterPartitionTracker partitionTracker,
+			final RescaleActionListener rescaleActionListener) throws Exception {
 
 		return new LegacyScheduler(
 			log,
@@ -83,6 +85,7 @@ public class LegacySchedulerFactory implements SchedulerNGFactory {
 			jobManagerJobMetricGroup,
 			slotRequestTimeout,
 			shuffleMaster,
-			partitionTracker);
+			partitionTracker,
+			rescaleActionListener);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacySchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LegacySchedulerFactory.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
-import org.apache.flink.runtime.rescale.RescaleActionListener;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 
@@ -66,8 +65,7 @@ public class LegacySchedulerFactory implements SchedulerNGFactory {
 			final JobManagerJobMetricGroup jobManagerJobMetricGroup,
 			final Time slotRequestTimeout,
 			final ShuffleMaster<?> shuffleMaster,
-			final JobMasterPartitionTracker partitionTracker,
-			final RescaleActionListener rescaleActionListener) throws Exception {
+			final JobMasterPartitionTracker partitionTracker) throws Exception {
 
 		return new LegacyScheduler(
 			log,
@@ -85,7 +83,7 @@ public class LegacySchedulerFactory implements SchedulerNGFactory {
 			jobManagerJobMetricGroup,
 			slotRequestTimeout,
 			shuffleMaster,
-			partitionTracker,
-			rescaleActionListener);
+			partitionTracker
+		);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -79,7 +79,6 @@ import org.apache.flink.runtime.query.KvStateLocation;
 import org.apache.flink.runtime.query.KvStateLocationRegistry;
 import org.apache.flink.runtime.query.UnknownKvStateLocation;
 import org.apache.flink.runtime.rescale.JobRescaleCoordinator;
-import org.apache.flink.runtime.rescale.RescaleActionListener;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
@@ -185,8 +184,7 @@ public abstract class SchedulerBase implements SchedulerNG {
 		final ShuffleMaster<?> shuffleMaster,
 		final JobMasterPartitionTracker partitionTracker,
 		final ExecutionVertexVersioner executionVertexVersioner,
-		final boolean legacyScheduling,
-		final RescaleActionListener rescaleActionListener) throws Exception {
+		final boolean legacyScheduling) throws Exception {
 
 		this.log = checkNotNull(log);
 		this.jobGraph = checkNotNull(jobGraph);
@@ -225,7 +223,7 @@ public abstract class SchedulerBase implements SchedulerNG {
 		this.inputsLocationsRetriever = new ExecutionGraphToInputsLocationsRetrieverAdapter(executionGraph);
 
 		this.jobRescaleCoordinator = new JobRescaleCoordinator(
-			jobGraph, executionGraph, userCodeLoader, rescaleActionListener);
+			jobGraph, executionGraph);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -228,6 +228,11 @@ public abstract class SchedulerBase implements SchedulerNG {
 			jobGraph, executionGraph, userCodeLoader, rescaleActionListener);
 	}
 
+	@Override
+	public JobRescaleCoordinator getJobRescaleCoordinator() {
+		return jobRescaleCoordinator;
+	}
+
 	private ExecutionGraph createAndRestoreExecutionGraph(
 		JobManagerJobMetricGroup currentJobManagerJobMetricGroup,
 		ShuffleMaster<?> shuffleMaster,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -79,6 +79,7 @@ import org.apache.flink.runtime.query.KvStateLocation;
 import org.apache.flink.runtime.query.KvStateLocationRegistry;
 import org.apache.flink.runtime.query.UnknownKvStateLocation;
 import org.apache.flink.runtime.rescale.JobRescaleCoordinator;
+import org.apache.flink.runtime.rescale.RescaleActionListener;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
@@ -184,7 +185,8 @@ public abstract class SchedulerBase implements SchedulerNG {
 		final ShuffleMaster<?> shuffleMaster,
 		final JobMasterPartitionTracker partitionTracker,
 		final ExecutionVertexVersioner executionVertexVersioner,
-		final boolean legacyScheduling) throws Exception {
+		final boolean legacyScheduling,
+		final RescaleActionListener rescaleActionListener) throws Exception {
 
 		this.log = checkNotNull(log);
 		this.jobGraph = checkNotNull(jobGraph);
@@ -223,7 +225,7 @@ public abstract class SchedulerBase implements SchedulerNG {
 		this.inputsLocationsRetriever = new ExecutionGraphToInputsLocationsRetrieverAdapter(executionGraph);
 
 		this.jobRescaleCoordinator = new JobRescaleCoordinator(
-			jobGraph, executionGraph, userCodeLoader);
+			jobGraph, executionGraph, userCodeLoader, rescaleActionListener);
 	}
 
 	private ExecutionGraph createAndRestoreExecutionGraph(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -458,7 +458,7 @@ public abstract class SchedulerBase implements SchedulerNG {
 	@Override
 	public void registerJobStatusListener(final JobStatusListener jobStatusListener) {
 		executionGraph.registerJobStatusListener(jobStatusListener);
-		executionGraph.registerJobStatusListener(jobRescaleCoordinator.createActivatorDeactivator());
+//		executionGraph.registerJobStatusListener(jobRescaleCoordinator.createActivatorDeactivator());
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.query.KvStateLocation;
 import org.apache.flink.runtime.query.UnknownKvStateLocation;
+import org.apache.flink.runtime.rescale.JobRescaleCoordinator;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
@@ -64,6 +65,8 @@ import java.util.concurrent.CompletableFuture;
  * will be passed via {@link #setMainThreadExecutor(ComponentMainThreadExecutor)}.
  */
 public interface SchedulerNG {
+
+	JobRescaleCoordinator getJobRescaleCoordinator();
 
 	void setMainThreadExecutor(ComponentMainThreadExecutor mainThreadExecutor);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNGFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNGFactory.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
+import org.apache.flink.runtime.rescale.RescaleActionListener;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 
@@ -55,6 +56,7 @@ public interface SchedulerNGFactory {
 		JobManagerJobMetricGroup jobManagerJobMetricGroup,
 		Time slotRequestTimeout,
 		ShuffleMaster<?> shuffleMaster,
-		JobMasterPartitionTracker partitionTracker) throws Exception;
+		JobMasterPartitionTracker partitionTracker,
+		RescaleActionListener rescaleActionListener) throws Exception;
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNGFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNGFactory.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
-import org.apache.flink.runtime.rescale.RescaleActionListener;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 
@@ -56,7 +55,6 @@ public interface SchedulerNGFactory {
 		JobManagerJobMetricGroup jobManagerJobMetricGroup,
 		Time slotRequestTimeout,
 		ShuffleMaster<?> shuffleMaster,
-		JobMasterPartitionTracker partitionTracker,
-		RescaleActionListener rescaleActionListener) throws Exception;
+		JobMasterPartitionTracker partitionTracker) throws Exception;
 
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmaster.JobMasterGateway;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
@@ -351,12 +352,7 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 	}
 
 	@Override
-	public void triggerJobRescale(JobRescaleAction.RescaleParamsWrapper wrapper, List<JobVertexID> involvedUpStream, List<JobVertexID> involvedDownStream) {
-
-	}
-
-	@Override
-	public void notifyStreamSwitchComplete(JobVertexID targetVertexID) {
+	public void triggerJobRescale(JobRescaleAction.RescaleParamsWrapper wrapper, JobGraph jobGraph, List<JobVertexID> involvedUpStream, List<JobVertexID> involvedDownStream) {
 
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -354,4 +354,9 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 	public void triggerJobRescale(JobRescaleAction.RescaleParamsWrapper wrapper, List<JobVertexID> involvedUpStream, List<JobVertexID> involvedDownStream) {
 
 	}
+
+	@Override
+	public void notifyStreamSwitchComplete(JobVertexID targetVertexID) {
+
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.query.KvStateLocation;
 import org.apache.flink.runtime.registration.RegistrationResponse;
+import org.apache.flink.runtime.rescale.JobRescaleAction;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStatsResponse;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -58,6 +59,7 @@ import javax.annotation.Nullable;
 
 import java.net.InetSocketAddress;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -346,5 +348,10 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 	@Override
 	public CompletableFuture<Object> updateGlobalAggregate(String aggregateName, Object aggregand, byte[] serializedAggregateFunction) {
 		return updateAggregateFunction.apply(aggregateName, aggregand, serializedAggregateFunction);
+	}
+
+	@Override
+	public void triggerJobRescale(JobRescaleAction.RescaleParamsWrapper wrapper, List<JobVertexID> involvedUpStream, List<JobVertexID> involvedDownStream) {
+
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
@@ -842,7 +842,8 @@ public class DefaultSchedulerTest extends TestLogger {
 			testRestartBackoffTimeStrategy,
 			testExecutionVertexOperations,
 			executionVertexVersioner,
-			executionSlotAllocatorFactory);
+			executionSlotAllocatorFactory,
+			null);
 	}
 
 	private void startScheduling(final SchedulerNG scheduler) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
@@ -842,8 +842,8 @@ public class DefaultSchedulerTest extends TestLogger {
 			testRestartBackoffTimeStrategy,
 			testExecutionVertexOperations,
 			executionVertexVersioner,
-			executionSlotAllocatorFactory,
-			null);
+			executionSlotAllocatorFactory
+		);
 	}
 
 	private void startScheduling(final SchedulerNG scheduler) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/LegacySchedulerBatchSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/LegacySchedulerBatchSchedulingTest.java
@@ -207,8 +207,8 @@ public class LegacySchedulerBatchSchedulingTest extends TestLogger {
 			UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup(),
 			slotRequestTimeout,
 			NettyShuffleMaster.INSTANCE,
-			NoOpJobMasterPartitionTracker.INSTANCE,
-			null);
+			NoOpJobMasterPartitionTracker.INSTANCE
+		);
 
 		legacyScheduler.setMainThreadExecutor(mainThreadExecutor);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/LegacySchedulerBatchSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/LegacySchedulerBatchSchedulingTest.java
@@ -207,7 +207,8 @@ public class LegacySchedulerBatchSchedulingTest extends TestLogger {
 			UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup(),
 			slotRequestTimeout,
 			NettyShuffleMaster.INSTANCE,
-			NoOpJobMasterPartitionTracker.INSTANCE);
+			NoOpJobMasterPartitionTracker.INSTANCE,
+			null);
 
 		legacyScheduler.setMainThreadExecutor(mainThreadExecutor);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/dispatcher/DefaultStreamManagerRunnerFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/dispatcher/DefaultStreamManagerRunnerFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.controlplane.dispatcher;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.webmonitor.retriever.LeaderGatewayRetriever;
 import org.apache.flink.streaming.controlplane.streammanager.StreamManagerConfiguration;
 import org.apache.flink.streaming.controlplane.streammanager.StreamManagerRunner;
@@ -44,12 +45,13 @@ public enum DefaultStreamManagerRunnerFactory implements StreamManagerRunnerFact
     INSTANCE;
 
     @Override
-    public StreamManagerRunner createStreamManagerRunner(
+    public StreamManagerRunnerImpl createStreamManagerRunner(
 		JobGraph jobGraph,
 		Configuration configuration,
 		RpcService rpcService,
 		HighAvailabilityServices highAvailabilityServices,
 		LeaderGatewayRetriever<DispatcherGateway> dispatcherGatewayRetriever,
+		LibraryCacheManager libraryCacheManager,
 		FatalErrorHandler fatalErrorHandler) throws Exception {
 
         final StreamManagerConfiguration streamManagerConfiguration = StreamManagerConfiguration.fromConfiguration(configuration);
@@ -58,6 +60,7 @@ public enum DefaultStreamManagerRunnerFactory implements StreamManagerRunnerFact
                 streamManagerConfiguration,
                 rpcService,
                 highAvailabilityServices,
+				libraryCacheManager,
 				dispatcherGatewayRetriever,
                 fatalErrorHandler
         );
@@ -71,6 +74,7 @@ public enum DefaultStreamManagerRunnerFactory implements StreamManagerRunnerFact
                 jobGraph,
                 streamManagerServiceFactory,
                 highAvailabilityServices,
+				libraryCacheManager,
                 futureExecutor,
                 fatalErrorHandler);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/dispatcher/StreamManagerRunnerFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/dispatcher/StreamManagerRunnerFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.controlplane.dispatcher;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.streaming.controlplane.streammanager.StreamManagerRunner;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -26,6 +27,7 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.webmonitor.retriever.LeaderGatewayRetriever;
+import org.apache.flink.streaming.controlplane.streammanager.StreamManagerRunnerImpl;
 
 /**
  * @author trx
@@ -34,11 +36,12 @@ import org.apache.flink.runtime.webmonitor.retriever.LeaderGatewayRetriever;
 @FunctionalInterface
 public interface StreamManagerRunnerFactory {
 
-	StreamManagerRunner createStreamManagerRunner(
+	StreamManagerRunnerImpl createStreamManagerRunner(
 		JobGraph jobGraph,
 		Configuration configuration,
 		RpcService rpcService,
 		HighAvailabilityServices highAvailabilityServices,
 		LeaderGatewayRetriever<DispatcherGateway> dispatcherGatewayRetriever,
+		LibraryCacheManager libraryCacheManager,
 		FatalErrorHandler fatalErrorHandler) throws Exception;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/controller/OperatorController.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/controller/OperatorController.java
@@ -1,4 +1,4 @@
-package org.apache.flink.runtime.rescale.controller;
+package org.apache.flink.streaming.controlplane.rescale.controller;
 
 import java.util.List;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/controller/OperatorControllerListener.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/controller/OperatorControllerListener.java
@@ -1,4 +1,4 @@
-package org.apache.flink.runtime.rescale.controller;
+package org.apache.flink.streaming.controlplane.rescale.controller;
 
 import java.util.List;
 import java.util.Map;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/metrics/KafkaMetricsRetriever.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/metrics/KafkaMetricsRetriever.java
@@ -1,4 +1,4 @@
-package org.apache.flink.runtime.rescale.metrics;
+package org.apache.flink.streaming.controlplane.rescale.metrics;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobEdge;
@@ -18,8 +18,8 @@ import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class StockMetricsRetriever implements StreamSwitchMetricsRetriever {
-	private static final Logger LOG = LoggerFactory.getLogger(StockMetricsRetriever.class);
+public class KafkaMetricsRetriever implements StreamSwitchMetricsRetriever {
+	private static final Logger LOG = LoggerFactory.getLogger(KafkaMetricsRetriever.class);
 	private AtomicBoolean closed = new AtomicBoolean();
 	private CountDownLatch shutdownLatch = new CountDownLatch(1);
 	private String servers;
@@ -49,8 +49,6 @@ public class StockMetricsRetriever implements StreamSwitchMetricsRetriever {
 	private long recordsCnt = 0;
 	private long lastoffset = 0;
 
-	Map<String, Integer> partitionStartPoint = new HashMap<>();
-
 	@Override
 	public void init(JobGraph jobGraph, JobVertexID vertexID, Configuration jobConfiguration, int numPartitions, int parallelism) {
 		this.jobGraph = jobGraph;
@@ -70,24 +68,6 @@ public class StockMetricsRetriever implements StreamSwitchMetricsRetriever {
 
 		this.numPartitions = numPartitions;
 		this.initialParallelism = parallelism;
-
-		// init start point, to make call auction be unaffected
-		String startPoint = "0=2954, 1=8249, 2=6849, 3=6597, 4=7717, 5=9297, 6=7174, 7=5887, " +
-			"8=3944, 9=10048, 10=4502, 11=5041, 12=5336, 13=7369, 14=5062, 15=3656, " +
-			"16=5156, 17=3763, 18=5682, 19=8535, 20=5773, 21=7610, 22=4476, 23=4064, " +
-			"24=5589, 25=10113, 26=10948, 27=4870, 28=5191, 29=9987, 30=3668, 31=6161, " +
-			"32=7568, 33=10165, 34=8349, 35=7766, 36=1593, 37=6272, 38=6491, 39=7987, " +
-			"40=7685, 41=6072, 42=8300, 43=5046, 44=3341, 45=8409, 46=10826, 47=4829, " +
-			"48=8051, 49=6798, 50=8151, 51=7670, 52=3940, 53=9452, 54=4411, 55=5760, " +
-			"56=7883, 57=10676, 58=10473, 59=4355, 60=13307, 61=3856, 62=5304, 63=4583";
-		String[] keyValuePairs = startPoint.split(",");              //split the string to creat key-value pairs
-
-		for(String pair : keyValuePairs)                        //iterate over the pairs
-		{
-			String[] entry = pair.split("=");                   //split the pairs to get key and value
-			partitionStartPoint.put(entry[0].trim(), Integer.valueOf(entry[1].trim()));          //add them to the hashmap and trim whitespaces
-		}
-
 		initConsumer();
 	}
 
@@ -100,15 +80,14 @@ public class StockMetricsRetriever implements StreamSwitchMetricsRetriever {
 		consumer = new KafkaConsumer(props);
 		consumer.subscribe(Arrays.asList(TOPIC));
 
-		System.out.println("consumer object: " + consumer.hashCode());
+		LOG.info("consumer object: " + consumer.hashCode());
 
 		ConsumerRecords<String, String> records = consumer.poll(100);
 		Set<TopicPartition> assignedPartitions = consumer.assignment();
 		for (TopicPartition partition : assignedPartitions) {
 			consumer.seek(partition, 0);
-//				System.out.println(vertexID + ": " + consumer.position(partition));
 			long endPosition = consumer.position(partition);
-			System.out.println("+++++++ cur vertex: " + vertexID.toString() + " start offset: " + endPosition);
+//			LOG.info("cur vertex: " + vertexID.toString() + " start offset: " + endPosition);
 		}
 	}
 
@@ -142,8 +121,8 @@ public class StockMetricsRetriever implements StreamSwitchMetricsRetriever {
 			for (TopicPartition partition : assignedPartitions) {
 //				System.out.println(vertexID + ": " + consumer.position(partition));
 				long endPosition = consumer.position(partition);
-				System.out.println("+++++++ cur vertex: " + vertexID.toString()
-					+ " consumer: " + consumer.hashCode() + " cur offset: " + endPosition);
+//				LOG.info("cur vertex: " + vertexID.toString()
+//					+ " consumer: " + consumer.hashCode() + " cur offset: " + endPosition);
 			}
 			if (!records.isEmpty()) {
 				// parse records, should construct metrics hashmap
@@ -171,7 +150,7 @@ public class StockMetricsRetriever implements StreamSwitchMetricsRetriever {
 				}
 			}
 
-			System.out.println("+++++++ cur vertex: " + vertexID.toString() + " records valid cnt: " + recordsCnt);
+//			LOG.info("cur vertex: " + vertexID.toString() + " records valid cnt: " + recordsCnt);
 		}
 
 		// aggregate partitionArrived
@@ -183,7 +162,6 @@ public class StockMetricsRetriever implements StreamSwitchMetricsRetriever {
 			}
 		}
 
-		// special case consideration
 		if (System.currentTimeMillis() - startTs < metrcsWarmUpTime*1000
 			&& partitionProcessedDelta.size() == 0 && partitionArrivedDelta.size() == 0) {
 			// make all metrics be 0.0
@@ -199,7 +177,6 @@ public class StockMetricsRetriever implements StreamSwitchMetricsRetriever {
 			}
 		}
 
-		// validity check
 		for (int i=0; i<numPartitions; i++) {
 			String partitionId = String.valueOf(i);
 			// update arrived if arrival has delta
@@ -208,22 +185,14 @@ public class StockMetricsRetriever implements StreamSwitchMetricsRetriever {
 				partitionArrivedState.put(partitionId,
 					partitionArrivedState.getOrDefault(partitionId, 0l)+partitionArrivedDelta.get(partitionId));
 			}
-			// save the latest arrived either last or this timeslot partitionarrived
-			// this value can be smaller than 0 if call auction doesn't complete
-			partitionArrived.put(partitionId,
-				partitionArrivedState.get(partitionId) - partitionStartPoint.get(partitionId));
+			// save the latest arrived either last or this timeslot to partitionarrived
+			partitionArrived.put(partitionId, partitionArrivedState.get(partitionId));
 
 			// need to check whether processed is valid
 			if (partitionProcessedDelta.containsKey(partitionId)) {
 				partitionProcessedState.put(partitionId,
 					partitionProcessedState.getOrDefault(partitionId, 0l)+partitionProcessedDelta.get(partitionId));
-				// this value can be < 0, do check whether this is < 0
-				partitionProcessed.put(partitionId,
-					partitionProcessedState.get(partitionId) - partitionStartPoint.get(partitionId));
-				if (partitionArrived.get(partitionId) < 0 || partitionProcessed.get(partitionId) < 0) {
-					partitionValid.put(partitionId, false);
-					continue;
-				}
+				partitionProcessed.put(partitionId, partitionProcessedState.get(partitionId));
 				// if this time processed is bigger than arrived, it means there must be some arrival
 				if (partitionArrived.get(partitionId) < partitionProcessed.get(partitionId)) {
 					partitionArrived.put(partitionId, partitionProcessed.get(partitionId));
@@ -233,8 +202,6 @@ public class StockMetricsRetriever implements StreamSwitchMetricsRetriever {
 				partitionValid.put(partitionId, false);
 			}
 		}
-
-		LOG.info("utilization: " + executorUtilization);
 
 		metrics.put("Arrived", partitionArrived);
 		metrics.put("Processed", partitionProcessed);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/metrics/StockMetricsRetriever.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/metrics/StockMetricsRetriever.java
@@ -1,4 +1,4 @@
-package org.apache.flink.runtime.rescale.metrics;
+package org.apache.flink.streaming.controlplane.rescale.metrics;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobEdge;
@@ -18,8 +18,8 @@ import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class KafkaMetricsRetriever implements StreamSwitchMetricsRetriever {
-	private static final Logger LOG = LoggerFactory.getLogger(KafkaMetricsRetriever.class);
+public class StockMetricsRetriever implements StreamSwitchMetricsRetriever {
+	private static final Logger LOG = LoggerFactory.getLogger(StockMetricsRetriever.class);
 	private AtomicBoolean closed = new AtomicBoolean();
 	private CountDownLatch shutdownLatch = new CountDownLatch(1);
 	private String servers;
@@ -49,6 +49,8 @@ public class KafkaMetricsRetriever implements StreamSwitchMetricsRetriever {
 	private long recordsCnt = 0;
 	private long lastoffset = 0;
 
+	Map<String, Integer> partitionStartPoint = new HashMap<>();
+
 	@Override
 	public void init(JobGraph jobGraph, JobVertexID vertexID, Configuration jobConfiguration, int numPartitions, int parallelism) {
 		this.jobGraph = jobGraph;
@@ -68,6 +70,24 @@ public class KafkaMetricsRetriever implements StreamSwitchMetricsRetriever {
 
 		this.numPartitions = numPartitions;
 		this.initialParallelism = parallelism;
+
+		// init start point, to make call auction be unaffected
+		String startPoint = "0=2954, 1=8249, 2=6849, 3=6597, 4=7717, 5=9297, 6=7174, 7=5887, " +
+			"8=3944, 9=10048, 10=4502, 11=5041, 12=5336, 13=7369, 14=5062, 15=3656, " +
+			"16=5156, 17=3763, 18=5682, 19=8535, 20=5773, 21=7610, 22=4476, 23=4064, " +
+			"24=5589, 25=10113, 26=10948, 27=4870, 28=5191, 29=9987, 30=3668, 31=6161, " +
+			"32=7568, 33=10165, 34=8349, 35=7766, 36=1593, 37=6272, 38=6491, 39=7987, " +
+			"40=7685, 41=6072, 42=8300, 43=5046, 44=3341, 45=8409, 46=10826, 47=4829, " +
+			"48=8051, 49=6798, 50=8151, 51=7670, 52=3940, 53=9452, 54=4411, 55=5760, " +
+			"56=7883, 57=10676, 58=10473, 59=4355, 60=13307, 61=3856, 62=5304, 63=4583";
+		String[] keyValuePairs = startPoint.split(",");              //split the string to creat key-value pairs
+
+		for(String pair : keyValuePairs)                        //iterate over the pairs
+		{
+			String[] entry = pair.split("=");                   //split the pairs to get key and value
+			partitionStartPoint.put(entry[0].trim(), Integer.valueOf(entry[1].trim()));          //add them to the hashmap and trim whitespaces
+		}
+
 		initConsumer();
 	}
 
@@ -80,14 +100,15 @@ public class KafkaMetricsRetriever implements StreamSwitchMetricsRetriever {
 		consumer = new KafkaConsumer(props);
 		consumer.subscribe(Arrays.asList(TOPIC));
 
-		LOG.info("consumer object: " + consumer.hashCode());
+		System.out.println("consumer object: " + consumer.hashCode());
 
 		ConsumerRecords<String, String> records = consumer.poll(100);
 		Set<TopicPartition> assignedPartitions = consumer.assignment();
 		for (TopicPartition partition : assignedPartitions) {
 			consumer.seek(partition, 0);
+//				System.out.println(vertexID + ": " + consumer.position(partition));
 			long endPosition = consumer.position(partition);
-//			LOG.info("cur vertex: " + vertexID.toString() + " start offset: " + endPosition);
+			System.out.println("+++++++ cur vertex: " + vertexID.toString() + " start offset: " + endPosition);
 		}
 	}
 
@@ -121,8 +142,8 @@ public class KafkaMetricsRetriever implements StreamSwitchMetricsRetriever {
 			for (TopicPartition partition : assignedPartitions) {
 //				System.out.println(vertexID + ": " + consumer.position(partition));
 				long endPosition = consumer.position(partition);
-//				LOG.info("cur vertex: " + vertexID.toString()
-//					+ " consumer: " + consumer.hashCode() + " cur offset: " + endPosition);
+				System.out.println("+++++++ cur vertex: " + vertexID.toString()
+					+ " consumer: " + consumer.hashCode() + " cur offset: " + endPosition);
 			}
 			if (!records.isEmpty()) {
 				// parse records, should construct metrics hashmap
@@ -150,7 +171,7 @@ public class KafkaMetricsRetriever implements StreamSwitchMetricsRetriever {
 				}
 			}
 
-//			LOG.info("cur vertex: " + vertexID.toString() + " records valid cnt: " + recordsCnt);
+			System.out.println("+++++++ cur vertex: " + vertexID.toString() + " records valid cnt: " + recordsCnt);
 		}
 
 		// aggregate partitionArrived
@@ -162,6 +183,7 @@ public class KafkaMetricsRetriever implements StreamSwitchMetricsRetriever {
 			}
 		}
 
+		// special case consideration
 		if (System.currentTimeMillis() - startTs < metrcsWarmUpTime*1000
 			&& partitionProcessedDelta.size() == 0 && partitionArrivedDelta.size() == 0) {
 			// make all metrics be 0.0
@@ -177,6 +199,7 @@ public class KafkaMetricsRetriever implements StreamSwitchMetricsRetriever {
 			}
 		}
 
+		// validity check
 		for (int i=0; i<numPartitions; i++) {
 			String partitionId = String.valueOf(i);
 			// update arrived if arrival has delta
@@ -185,14 +208,22 @@ public class KafkaMetricsRetriever implements StreamSwitchMetricsRetriever {
 				partitionArrivedState.put(partitionId,
 					partitionArrivedState.getOrDefault(partitionId, 0l)+partitionArrivedDelta.get(partitionId));
 			}
-			// save the latest arrived either last or this timeslot to partitionarrived
-			partitionArrived.put(partitionId, partitionArrivedState.get(partitionId));
+			// save the latest arrived either last or this timeslot partitionarrived
+			// this value can be smaller than 0 if call auction doesn't complete
+			partitionArrived.put(partitionId,
+				partitionArrivedState.get(partitionId) - partitionStartPoint.get(partitionId));
 
 			// need to check whether processed is valid
 			if (partitionProcessedDelta.containsKey(partitionId)) {
 				partitionProcessedState.put(partitionId,
 					partitionProcessedState.getOrDefault(partitionId, 0l)+partitionProcessedDelta.get(partitionId));
-				partitionProcessed.put(partitionId, partitionProcessedState.get(partitionId));
+				// this value can be < 0, do check whether this is < 0
+				partitionProcessed.put(partitionId,
+					partitionProcessedState.get(partitionId) - partitionStartPoint.get(partitionId));
+				if (partitionArrived.get(partitionId) < 0 || partitionProcessed.get(partitionId) < 0) {
+					partitionValid.put(partitionId, false);
+					continue;
+				}
 				// if this time processed is bigger than arrived, it means there must be some arrival
 				if (partitionArrived.get(partitionId) < partitionProcessed.get(partitionId)) {
 					partitionArrived.put(partitionId, partitionProcessed.get(partitionId));
@@ -202,6 +233,8 @@ public class KafkaMetricsRetriever implements StreamSwitchMetricsRetriever {
 				partitionValid.put(partitionId, false);
 			}
 		}
+
+		LOG.info("utilization: " + executorUtilization);
 
 		metrics.put("Arrived", partitionArrived);
 		metrics.put("Processed", partitionProcessed);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/metrics/StreamSwitchMetricsRetriever.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/metrics/StreamSwitchMetricsRetriever.java
@@ -1,4 +1,4 @@
-package org.apache.flink.runtime.rescale.metrics;
+package org.apache.flink.streaming.controlplane.rescale.metrics;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobGraph;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/streamswitch/DummyStreamSwitch.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/streamswitch/DummyStreamSwitch.java
@@ -1,19 +1,15 @@
-package org.apache.flink.runtime.rescale.streamswitch;
+package org.apache.flink.streaming.controlplane.rescale.streamswitch;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.rescale.controller.OperatorControllerListener;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
+import org.apache.flink.streaming.controlplane.rescale.controller.OperatorControllerListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 
 public class DummyStreamSwitch extends Thread implements FlinkOperatorController {
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/streamswitch/FlinkOperatorController.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/streamswitch/FlinkOperatorController.java
@@ -1,9 +1,9 @@
-package org.apache.flink.runtime.rescale.streamswitch;
+package org.apache.flink.streaming.controlplane.rescale.streamswitch;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.rescale.controller.OperatorController;
+import org.apache.flink.streaming.controlplane.rescale.controller.OperatorController;
 
 public interface FlinkOperatorController extends OperatorController {
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/streamswitch/FlinkStreamSwitchAdaptor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/streamswitch/FlinkStreamSwitchAdaptor.java
@@ -103,12 +103,6 @@ public class FlinkStreamSwitchAdaptor {
 	}
 
 	public void onChangeImplemented(JobVertexID jobVertexID) {
-		// sleep period of time
-//		try {
-//			Thread.sleep(migrationInterval);
-//		} catch (InterruptedException e) {
-//			e.printStackTrace();
-//		}
 		LOG.info("++++++ onChangeImplemented triggered for jobVertex " + jobVertexID);
 		this.controllers.get(jobVertexID).onMigrationCompleted();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/streamswitch/Pair.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/streamswitch/Pair.java
@@ -1,4 +1,4 @@
-package org.apache.flink.runtime.rescale.streamswitch;
+package org.apache.flink.streaming.controlplane.rescale.streamswitch;
 
 import java.io.Serializable;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/streamswitch/StreamSwitch.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/streamswitch/StreamSwitch.java
@@ -1,14 +1,14 @@
-package org.apache.flink.runtime.rescale.streamswitch;
+package org.apache.flink.streaming.controlplane.rescale.streamswitch;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.rescale.controller.OperatorControllerListener;
-import org.apache.flink.runtime.rescale.metrics.KafkaMetricsRetriever;
-import org.apache.flink.runtime.rescale.metrics.StockMetricsRetriever;
-import org.apache.flink.runtime.rescale.metrics.StreamSwitchMetricsRetriever;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
+import org.apache.flink.streaming.controlplane.rescale.controller.OperatorControllerListener;
+import org.apache.flink.streaming.controlplane.rescale.metrics.KafkaMetricsRetriever;
+import org.apache.flink.streaming.controlplane.rescale.metrics.StockMetricsRetriever;
+import org.apache.flink.streaming.controlplane.rescale.metrics.StreamSwitchMetricsRetriever;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/streammanager/StreamManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/streammanager/StreamManager.java
@@ -298,6 +298,12 @@ public class StreamManager extends FencedRpcEndpoint<StreamManagerId> implements
 		runAsync(() -> jobMasterGateway.triggerJobRescale(wrapper, upDownStream.f0, upDownStream.f1));
 	}
 
+	@Override
+	public void streamSwitchComplete(JobVertexID targetVertexID) {
+		streamSwitchAdaptor.onMigrationExecutorsStopped(targetVertexID);
+		streamSwitchAdaptor.onChangeImplemented(targetVertexID);
+	}
+
 
 	//----------------------------------------------------------------------------------------------
 	// Internal methods

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/streammanager/StreamManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/streammanager/StreamManager.java
@@ -278,6 +278,10 @@ public class StreamManager extends FencedRpcEndpoint<StreamManagerId> implements
 		Tuple2<List<JobVertexID>, List<JobVertexID>> involvedUpDownStream = null;
 		switch (wrapper.type) {
 			case SCALE_IN:
+				involvedUpDownStream = jobGraphRescaler.repartition(
+					wrapper.vertexID,
+					wrapper.jobRescalePartitionAssignment.getPartitionAssignment());
+				break;
 			case SCALE_OUT:
 				involvedUpDownStream = jobGraphRescaler.rescale(
 					wrapper.vertexID,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/streammanager/StreamManagerRunner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/streammanager/StreamManagerRunner.java
@@ -42,7 +42,7 @@ public interface StreamManagerRunner extends AutoCloseableAsync {
 	 *
 	 * @return Future with the JobMasterGateway once the underlying JobMaster becomes leader
 	 */
-	CompletableFuture<StreamManagerGateway> getJobMasterGateway();
+	CompletableFuture<StreamManagerGateway> getStreamManagerGateway();
 
 	/**
 	 * Get the job id of the executed job.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/streammanager/StreamManagerRunnerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/streammanager/StreamManagerRunnerImpl.java
@@ -24,13 +24,14 @@ import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.controlplane.streammanager.StreamManagerGateway;
 import org.apache.flink.runtime.controlplane.streammanager.StreamManagerId;
+import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
+import org.apache.flink.runtime.jobmaster.JobNotFinishedException;
 import org.apache.flink.streaming.controlplane.streammanager.factories.StreamManagerServiceFactory;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.leaderelection.LeaderContender;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
-import org.apache.flink.runtime.leaderelection.StandaloneLeaderElectionService;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.util.ExceptionUtils;
@@ -39,6 +40,7 @@ import org.apache.flink.util.function.FunctionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -69,8 +71,7 @@ public class StreamManagerRunnerImpl implements LeaderContender, StreamManagerRu
 	/** Leader election for this stream manger. */
 	private final LeaderElectionService leaderElectionService;
 
-// TODO: use LCM
-//	private final LibraryCacheManager libraryCacheManager;
+	private final LibraryCacheManager libraryCacheManager;
 
 	private final Executor executor;
 
@@ -99,11 +100,12 @@ public class StreamManagerRunnerImpl implements LeaderContender, StreamManagerRu
 	 *                   required services could not be started, or the Job could not be initialized.
 	 */
 	public StreamManagerRunnerImpl(
-			final JobGraph jobGraph,
-			final StreamManagerServiceFactory streamManagerFactory,
-			final HighAvailabilityServices haServices,
-			final Executor executor,
-			final FatalErrorHandler fatalErrorHandler) throws Exception {
+		final JobGraph jobGraph,
+		final StreamManagerServiceFactory streamManagerFactory,
+		final HighAvailabilityServices haServices,
+		final LibraryCacheManager libraryCacheManager,
+		final Executor executor,
+		final FatalErrorHandler fatalErrorHandler) throws Exception {
 
 		this.resultFuture = new CompletableFuture<>();
 		this.terminationFuture = new CompletableFuture<>();
@@ -114,20 +116,30 @@ public class StreamManagerRunnerImpl implements LeaderContender, StreamManagerRu
 			this.jobGraph = checkNotNull(jobGraph);
 			this.executor = checkNotNull(executor);
 			this.fatalErrorHandler = checkNotNull(fatalErrorHandler);
+			this.libraryCacheManager = checkNotNull(libraryCacheManager);
 
 			checkArgument(jobGraph.getNumberOfVertices() > 0, "The given job is empty");
 
 			// libraries and class loader first
+			try {
+				libraryCacheManager.registerJob(
+					jobGraph.getJobID(), jobGraph.getUserJarBlobKeys(), jobGraph.getClasspaths());
+			} catch (IOException e) {
+				throw new Exception("Cannot set up the user code libraries: " + e.getMessage(), e);
+			}
+
+			final ClassLoader userCodeLoader = libraryCacheManager.getClassLoader(jobGraph.getJobID());
+			if (userCodeLoader == null) {
+				throw new Exception("The user code class loader could not be initialized.");
+			}
 
 			// high availability services next
-			// TODO: 1. change back and 2. add getStreamManagerLES in HA
-//			this.leaderElectionService = haServices.getJobManagerLeaderElectionService(jobGraph.getJobID());
-			this.leaderElectionService = new StandaloneLeaderElectionService();
+			this.leaderElectionService = haServices.getJobManagerLeaderElectionService(jobGraph.getJobID());
 
 			this.leaderGatewayFuture = new CompletableFuture<>();
 
 			// now start the StreamManager
-			this.streamManagerService = streamManagerFactory.createStreamManagerService(jobGraph);
+			this.streamManagerService = streamManagerFactory.createStreamManagerService(jobGraph, userCodeLoader);
 		}
 		catch (Throwable t) {
 			terminationFuture.completeExceptionally(t);
@@ -142,7 +154,7 @@ public class StreamManagerRunnerImpl implements LeaderContender, StreamManagerRu
 	//----------------------------------------------------------------------------------------------
 
 	@Override
-	public CompletableFuture<StreamManagerGateway> getJobMasterGateway() {
+	public CompletableFuture<StreamManagerGateway> getStreamManagerGateway() {
 		return leaderGatewayFuture;
 	}
 
@@ -170,7 +182,34 @@ public class StreamManagerRunnerImpl implements LeaderContender, StreamManagerRu
 		synchronized (lock) {
 			if (!shutdown) {
 				shutdown = true;
-				// TODO
+
+				setNewLeaderGatewayFuture();
+				leaderGatewayFuture.completeExceptionally(new FlinkException("JobMaster has been shut down."));
+
+				final CompletableFuture<Void> jobManagerTerminationFuture = streamManagerService.closeAsync();
+
+				jobManagerTerminationFuture.whenComplete(
+					(Void ignored, Throwable throwable) -> {
+						try {
+							leaderElectionService.stop();
+						} catch (Throwable t) {
+							throwable = ExceptionUtils.firstOrSuppressed(t, ExceptionUtils.stripCompletionException(throwable));
+						}
+
+						libraryCacheManager.unregisterJob(jobGraph.getJobID());
+
+						if (throwable != null) {
+							terminationFuture.completeExceptionally(
+								new FlinkException("Could not properly shut down the JobManagerRunner", throwable));
+						} else {
+							terminationFuture.complete(null);
+						}
+					});
+
+				terminationFuture.whenComplete(
+					(Void ignored, Throwable throwable) -> {
+						resultFuture.completeExceptionally(new JobNotFinishedException(jobGraph.getJobID()));
+					});
 			}
 
 			return terminationFuture;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/streammanager/factories/DefaultStreamManagerServiceFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/streammanager/factories/DefaultStreamManagerServiceFactory.java
@@ -20,7 +20,7 @@ package org.apache.flink.streaming.controlplane.streammanager.factories;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
-import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.webmonitor.retriever.LeaderGatewayRetriever;
 import org.apache.flink.streaming.controlplane.streammanager.StreamManager;
 import org.apache.flink.streaming.controlplane.streammanager.StreamManagerConfiguration;
@@ -55,6 +55,7 @@ public class DefaultStreamManagerServiceFactory implements StreamManagerServiceF
 		StreamManagerConfiguration streamManagerConfiguration,
 		RpcService rpcService,
 		HighAvailabilityServices haServices,
+		LibraryCacheManager libraryCacheManager,
 		LeaderGatewayRetriever<DispatcherGateway> dispatcherGatewayRetriever,
 		FatalErrorHandler fatalErrorHandler) {
 		this.streamManagerConfiguration = streamManagerConfiguration;
@@ -66,7 +67,7 @@ public class DefaultStreamManagerServiceFactory implements StreamManagerServiceF
 
 	@Override
 	public StreamManager createStreamManagerService(
-			JobGraph jobGraph) throws Exception {
+		JobGraph jobGraph, ClassLoader userCodeLoader) throws Exception {
 		final StreamManagerRuntimeServices streamManagerRuntimeServices = StreamManagerRuntimeServices.fromConfiguration(
 				streamManagerConfiguration,
 				haServices,
@@ -77,6 +78,7 @@ public class DefaultStreamManagerServiceFactory implements StreamManagerServiceF
 			streamManagerConfiguration,
 			ResourceID.generate(),
 			jobGraph,
+			userCodeLoader,
 			haServices,
 			streamManagerRuntimeServices.getJobLeaderIdService(),
 			dispatcherGatewayRetriever,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/streammanager/factories/StreamManagerServiceFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/streammanager/factories/StreamManagerServiceFactory.java
@@ -27,5 +27,6 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 public interface StreamManagerServiceFactory {
 
 	StreamManagerService createStreamManagerService(
-		JobGraph jobGraph) throws Exception;
+		JobGraph jobGraph,
+		ClassLoader userCodeLoader) throws Exception;
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/controlplane/dispatcher/StreamManagerDispatcherTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/controlplane/dispatcher/StreamManagerDispatcherTest.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.streaming.controlplane.streammanager.StreamManagerRunner;
+import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.dispatcher.*;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -390,17 +390,17 @@ public class StreamManagerDispatcherTest extends TestLogger {
 		}
 
 		@Override
-		public StreamManagerRunner createStreamManagerRunner(
+		public StreamManagerRunnerImpl createStreamManagerRunner(
 			JobGraph jobGraph,
 			Configuration configuration,
 			RpcService rpcService,
 			HighAvailabilityServices highAvailabilityServices,
 			LeaderGatewayRetriever<DispatcherGateway> dispatcherGatewayRetriever,
-			FatalErrorHandler fatalErrorHandler) throws Exception {
+			LibraryCacheManager libraryCacheManager, FatalErrorHandler fatalErrorHandler) throws Exception {
 
 			final StreamManagerConfiguration streamManagerConfiguration = StreamManagerConfiguration.fromConfiguration(configuration);
 
-			final StreamManagerServiceFactory streamManagerServiceFactory = jobGraph1 -> {
+			final StreamManagerServiceFactory streamManagerServiceFactory = (jobGraph1, userCodeLoader) -> {
 				final StreamManagerRuntimeServices streamManagerRuntimeServices = StreamManagerRuntimeServices.fromConfiguration(
 					streamManagerConfiguration,
 					highAvailabilityServices,
@@ -426,7 +426,7 @@ public class StreamManagerDispatcherTest extends TestLogger {
 				jobGraph,
 				streamManagerServiceFactory,
 				highAvailabilityServices,
-				futureExecutor,
+				libraryCacheManager, futureExecutor,
 				fatalErrorHandler);
 		}
 	}
@@ -444,13 +444,13 @@ public class StreamManagerDispatcherTest extends TestLogger {
 		}
 
 		@Override
-		public StreamManagerRunner createStreamManagerRunner(
+		public StreamManagerRunnerImpl createStreamManagerRunner(
 			JobGraph jobGraph,
 			Configuration configuration,
 			RpcService rpcService,
 			HighAvailabilityServices highAvailabilityServices,
 			LeaderGatewayRetriever<DispatcherGateway> dispatcherGatewayRetriever,
-			FatalErrorHandler fatalErrorHandler) {
+			LibraryCacheManager libraryCacheManager, FatalErrorHandler fatalErrorHandler) {
 
 			createdJobManagerRunnerLatch.countDown();
 
@@ -461,7 +461,7 @@ public class StreamManagerDispatcherTest extends TestLogger {
 					rpcService,
 					highAvailabilityServices,
 					dispatcherGatewayRetriever,
-					fatalErrorHandler);
+					null, fatalErrorHandler);
 			} catch (Exception e) {
 				e.printStackTrace();
 			}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/controlplane/dispatcher/StreamManagerDispatcherTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/controlplane/dispatcher/StreamManagerDispatcherTest.java
@@ -314,8 +314,7 @@ public class StreamManagerDispatcherTest extends TestLogger {
 		CompletableFuture<Acknowledge> acknowledgeFuture = dispatcherGateway.submitJob(jobGraph, RpcUtils.INF_TIMEOUT);
 
 		assertEquals("stream manager runner do not start", Acknowledge.get(), acknowledgeFuture.get(3, TimeUnit.SECONDS));
-		assertEquals("job master can not connect to stream manager", Acknowledge.get(), isRegisterJobManagerFuture.get(3, TimeUnit.HOURS));
-		Thread.sleep(100000000);
+		assertEquals("job master can not connect to stream manager", Acknowledge.get(), isRegisterJobManagerFuture.get(3, TimeUnit.SECONDS));
 	}
 
 	@Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/controlplane/dispatcher/StreamManagerDispatcherTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/controlplane/dispatcher/StreamManagerDispatcherTest.java
@@ -315,6 +315,7 @@ public class StreamManagerDispatcherTest extends TestLogger {
 
 		assertEquals("stream manager runner do not start", Acknowledge.get(), acknowledgeFuture.get(3, TimeUnit.SECONDS));
 		assertEquals("job master can not connect to stream manager", Acknowledge.get(), isRegisterJobManagerFuture.get(3, TimeUnit.SECONDS));
+		Thread.sleep(100000000);
 	}
 
 	@Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/controlplane/dispatcher/StreamManagerDispatcherTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/controlplane/dispatcher/StreamManagerDispatcherTest.java
@@ -314,7 +314,7 @@ public class StreamManagerDispatcherTest extends TestLogger {
 		CompletableFuture<Acknowledge> acknowledgeFuture = dispatcherGateway.submitJob(jobGraph, RpcUtils.INF_TIMEOUT);
 
 		assertEquals("stream manager runner do not start", Acknowledge.get(), acknowledgeFuture.get(3, TimeUnit.SECONDS));
-		assertEquals("job master can not connect to stream manager", Acknowledge.get(), isRegisterJobManagerFuture.get(3, TimeUnit.SECONDS));
+		assertEquals("job master can not connect to stream manager", Acknowledge.get(), isRegisterJobManagerFuture.get(3, TimeUnit.HOURS));
 		Thread.sleep(100000000);
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/controlplane/streammanager/TestingStreamManager.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/controlplane/streammanager/TestingStreamManager.java
@@ -51,6 +51,7 @@ public class TestingStreamManager extends StreamManager {
 			streamManagerConfiguration,
 			resourceId,
 			jobGraph,
+			null,
 			highAvailabilityService,
 			jobLeaderIdService,
 			dispatcherGatewayRetriever,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/controlplane/streammanager/TestingStreamManager.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/controlplane/streammanager/TestingStreamManager.java
@@ -59,8 +59,8 @@ public class TestingStreamManager extends StreamManager {
 	}
 
 	@Override
-	public CompletableFuture<RegistrationResponse> registerJobManager(JobMasterId jobMasterId, ResourceID jobManagerResourceId, String jobManagerAddress, JobID jobId, Time timeout) {
+	public CompletableFuture<RegistrationResponse> registerJobManager(JobMasterId jobMasterId, ResourceID jobManagerResourceId, String jobManagerAddress, JobID jobId,ClassLoader userCodeLoader ,Time timeout) {
 		isRegisterJob.complete(Acknowledge.get());
-		return super.registerJobManager(jobMasterId, jobManagerResourceId, jobManagerAddress, jobId, timeout);
+		return super.registerJobManager(jobMasterId, jobManagerResourceId, jobManagerAddress, jobId, userCodeLoader, timeout);
 	}
 }


### PR DESCRIPTION
<!--
这个模板是我根据flink官方提供的pull request的模板适配的。
尽量根据这个pull request模板附上pull request的信息吧！
-->

## What is the purpose of the change
将StreamSwitch相关模块还有JobGraphRescale移动到streaming中，由StreamManager初始化，之后也由StreamManager调用JobMaster的gateway来让JobRescaleCoordinator　rescale Job

## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
