### PR TITLE
Fix bug of get input gate deployment descriptor

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -123,7 +123,7 @@ public class SingleInputGate extends InputGate {
 	 * The index of the consumed subpartition of each consumed partition. This index depends on the
 	 * {@link DistributionPattern} and the subtask indices of the producing and consuming task.
 	 */
-	private final int consumedSubpartitionIndex;
+	private int consumedSubpartitionIndex;
 
 	/** The number of input channels (equivalent to the number of consumed partitions). */
 	private int numberOfInputChannels;
@@ -262,6 +262,9 @@ public class SingleInputGate extends InputGate {
 		return consumedSubpartitionIndex;
 	}
 
+	public void setConsumedSubpartitionIndex(int consumedSubpartitionIndex) {
+		this.consumedSubpartitionIndex = consumedSubpartitionIndex;
+	}
 	/**
 	 * Returns the type of this input channel's consumed result partition.
 	 *

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/streamswitch/FlinkStreamSwitchAdaptor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/streamswitch/FlinkStreamSwitchAdaptor.java
@@ -13,10 +13,7 @@ import org.apache.flink.streaming.controlplane.rescale.controller.OperatorContro
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.apache.flink.runtime.rescale.JobRescaleAction.ActionType.REPARTITION;
 import static org.apache.flink.runtime.rescale.JobRescaleAction.ActionType.SCALE_OUT;
@@ -54,19 +51,15 @@ public class FlinkStreamSwitchAdaptor {
 //			if (!entry.getValue().getName().toLowerCase().contains("join") && !entry.getValue().getName().toLowerCase().contains("window")) {
 //				continue;
 //			}
-			FlinkOperatorController controller;
-
-			if (jobVertex.getName().toLowerCase().contains("map")) {
-//				controller = new DummyStreamSwitch("map");
+			final FlinkOperatorController controller;
+			if(jobVertex.getName().equals("near source Flatmap")){
+				controller = ConfigurableDummyStreamSwitch.createFromPara(
+					RescaleActionDescriptor.BaseRescaleAction.ActionType.SCALE_OUT,
+					2);
+			}else {
 				continue;
-			} else if (jobVertex.getName().toLowerCase().contains("filter")) {
-				controller = new DummyStreamSwitch("filter");
-			} else {
-				controller = ConfigurableDummyStreamSwitch.createFromJobVertex(jobVertex.getName());
-				if (controller == null) {
-					continue;
-				}
 			}
+
 			config.setString("vertex_id", vertexID.toString());
 //			FlinkOperatorController controller = new LatencyGuarantor(config);
 			OperatorControllerListener listener = new OperatorControllerListenerImpl(vertexID, parallelism, maxParallelism);


### PR DESCRIPTION
<!--
这个模板是我根据flink官方提供的pull request的模板适配的。
尽量根据这个pull request模板附上pull request的信息吧！
-->

## What is the purpose of the change
fix bug of rescaling `FORWARD` partition type operator

## Brief change log
- change implementation of method:
```
public InputGateDeploymentDescriptor getMatchedInputGateDescriptor(SingleInputGate gate);
```
- update `consumedSubpartitionIndex` of InputGate


