### PR TITLE
Forward op fix

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -123,7 +123,7 @@ public class SingleInputGate extends InputGate {
 	 * The index of the consumed subpartition of each consumed partition. This index depends on the
 	 * {@link DistributionPattern} and the subtask indices of the producing and consuming task.
 	 */
-	private final int consumedSubpartitionIndex;
+	private int consumedSubpartitionIndex;
 
 	/** The number of input channels (equivalent to the number of consumed partitions). */
 	private int numberOfInputChannels;
@@ -262,6 +262,9 @@ public class SingleInputGate extends InputGate {
 		return consumedSubpartitionIndex;
 	}
 
+	public void setConsumedSubpartitionIndex(int consumedSubpartitionIndex) {
+		this.consumedSubpartitionIndex = consumedSubpartitionIndex;
+	}
 	/**
 	 * Returns the type of this input channel's consumed result partition.
 	 *

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/streamswitch/ConfigurableDummyStreamSwitch.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/controlplane/rescale/streamswitch/ConfigurableDummyStreamSwitch.java
@@ -211,8 +211,7 @@ public class ConfigurableDummyStreamSwitch implements FlinkOperatorController, R
 					otherKeys.add(firstSubTask.get(i));
 				}
 			}
-			executorMapping.get("0").clear();
-			executorMapping.get("0").addAll(originKeys);
+			executorMapping.put("0", originKeys);
 			executorMapping.get(String.valueOf(newParallelism-1)).addAll(otherKeys);
 		}else {
 			// scale in


### PR DESCRIPTION
<!--
这个模板是我根据flink官方提供的pull request的模板适配的。
尽量根据这个pull request模板附上pull request的信息吧！
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*

## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
